### PR TITLE
match user's slack status to their irc status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -41,6 +41,7 @@ class Irslackd {
     this.socketMap.delete(socket);
     this.rtmMap.delete(ircUser.slackRtm);
     ircUser.slackRtm.disconnect();
+    this.setSlackPresence(ircUser, false);
   }
   onIrcPass(ircUser, msg) {
     ircUser.slackToken = msg.args[0] || '';
@@ -238,6 +239,9 @@ class Irslackd {
     // Send MOTD
     this.ircd.write(ircUser.socket, 'irslackd', '001', [ ircUser.ircNick, 'irslackd' ]);
     this.ircd.write(ircUser.socket, 'irslackd', '376', [ ircUser.ircNick, 'End of MOTD' ]);
+
+    // set user presence to auto instead of away
+    this.setSlackPresence(ircUser, true);
 
     // Refresh Slack users and channels
     // Await on usernames as they are needed before populating channels
@@ -493,8 +497,17 @@ class Irslackd {
     }
     return results;
   }
+  async setSlackPresence(ircUser, active) {
+      let status = (active) ? 'auto' : 'away';
+      let presence;
+      try {
+          presence = await ircUser.slackWeb.apiCall('users.setPresence', { presence: status });
+          if (!presence.ok) throw user;
+      } catch (e) {
+          this.logError(ircUser, 'Failed users.setPresence: ' + util.inspect(e));
+      }
+  }
 }
-
 class IrcUser {
   constructor(socket) {
     this.socket = socket;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -16,14 +16,15 @@ class Irslackd {
     self.socketMap = new Map();
     self.ircd = new ircd.Ircd(config.tlsOpts);
     new Map([
-      [ 'PASS',    self.makeIrcHandler(self.onIrcPass)    ],
-      [ 'NICK',    self.makeIrcHandler(self.onIrcNick)    ],
-      [ 'USER',    self.makeIrcHandler(self.onIrcUser)    ],
+      [ 'AWAY',    self.makeIrcHandler(self.onIrcAway)    ],
       [ 'JOIN',    self.makeIrcHandler(self.onIrcJoin)    ],
+      [ 'NICK',    self.makeIrcHandler(self.onIrcNick)    ],
       [ 'PART',    self.makeIrcHandler(self.onIrcPart)    ],
+      [ 'PASS',    self.makeIrcHandler(self.onIrcPass)    ],
       [ 'PRIVMSG', self.makeIrcHandler(self.onIrcPrivmsg) ],
       [ 'PING',    self.makeIrcHandler(self.onIrcPing)    ],
       [ 'QUIT',    self.makeIrcHandler(self.onIrcQuit)    ],
+      [ 'USER',    self.makeIrcHandler(self.onIrcUser)    ],
       [ 'msg',     self.makeIrcHandler(self.onIrcMsg)     ],
       [ 'line',    self.makeIrcHandler(self.onIrcLine)    ],
       [ 'error',   self.makeIrcHandler(self.onIrcError)   ],
@@ -84,6 +85,26 @@ class Irslackd {
 
     // Start RTM
     ircUser.slackRtm.start();
+  }
+  async onIrcAway(ircUser, msg) {
+      // if args is empty, unset away status
+      let status;
+      if (msg.args.length == 0) {
+          status = '';
+          this.setSlackPresence(ircUser, true);
+      } else {
+          status = msg.args[0];
+          // slack statuses are capped at 100 characters
+          status = status.substring(0, 100);
+          this.setSlackPresence(ircUser, false);
+      }
+      let profile;
+      try {
+          profile = await ircUser.slackWeb.apiCall('users.profile.set', { profile: { status_text: status , status_emoji: '' } });
+          if (!profile.ok) throw profile;
+      } catch(e) {
+          this.logError(ircUser, 'Failed users.profile.set: ' + util.inspect(e));
+      }
   }
   async onIrcJoin(ircUser, msg) {
     let ircChan = msg.args[0];

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -529,6 +529,7 @@ class Irslackd {
       }
   }
 }
+
 class IrcUser {
   constructor(socket) {
     this.socket = socket;


### PR DESCRIPTION
This change adds the ability to set a user's slack [presence and status](https://api.slack.com/docs/presence-and-status) based on their irc status. On irslackd server connect, a user will be marked as `auto` and will be set to `away` on irslackd server disconnect. Also adds support for irc `/away` command, setting a users slack status to their irc away status. 