### PR TITLE
Implement sending and receiving user_typing events

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -99,6 +99,7 @@ class Irslackd {
       [ 'reaction_removed',      self.makeSlackHandler(self.onSlackReactionRemoved)     ],
       [ 'subteam_created',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
       [ 'subteam_updated',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
+      [ 'user_typing',           self.makeSlackHandler(self.onSlackUserTyping)          ],
       [ 'slack_event',           self.makeSlackHandler(self.onSlackEvent)               ],
     ]).forEach((handler, event, map) => {
       ircUser.slackRtm.on(event, handler);
@@ -269,12 +270,17 @@ class Irslackd {
 
     // Check for /me message
     let apiMethod = 'chat.postMessage';
-    if (message.charCodeAt(0) === 1 && message.substr(1, 7) === 'ACTION ') {
+    if (this.isCtcpCommand('ACTION', message)) {
       apiMethod = 'chat.meMessage';
       message = message.substr(8);
       if (message.charCodeAt(message.length - 1) === 1) {
         message = message.substr(0, message.length - 1);
       }
+    }
+
+    // Check for CTCP TYPING message
+    if (ircUser.typingNotificationsEnabled() && this.isCtcpCommand('TYPING', message)) {
+      return await ircUser.slackRtm.sendTyping(slackChan);
     }
 
     // Call chat.(post|me)Message
@@ -545,6 +551,19 @@ class Irslackd {
     let message = this.meText(verb + ' @ ' + ircReactee + ' :' + event.reaction + ':');
     this.ircd.write(ircUser.socket, ircReacter, 'PRIVMSG', [ ircChan, message ]);
   }
+  async onSlackUserTyping(ircUser, event) {
+    if (!ircUser.typingNotificationsEnabled()) {
+      return;
+    }
+    let [ircNick, ircTarget] = await this.resolveSlackTarget(ircUser, event);
+    if (!ircNick || !ircTarget) {
+      this.logError(ircUser, 'Failed this.resolveSlackTarget; event: ' + util.inspect(event));
+      return;
+    }
+    console.log('slack_typing', ircNick, ircTarget);
+    let line = this.typingText('1');
+    this.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ ircTarget, line ]);
+  }
   async onIrcWho(ircUser, msg) {
     await this.onIrcWhois(ircUser, msg);
   }
@@ -707,8 +726,18 @@ class Irslackd {
       this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [ ircChan ]);
     }
   }
+  ctcpCommand(command, text) {
+    return String.fromCharCode(1) + command + ' ' + text + String.fromCharCode(1);
+  }
+  isCtcpCommand(command, message) {
+    command = command + ' ';
+    return message.charCodeAt(0) === 1 && message.substr(1, command.length) === command;
+  }
   meText(text) {
-    return String.fromCharCode(1) + 'ACTION ' + text + String.fromCharCode(1);
+    return this.ctcpCommand('ACTION', text);
+  }
+  typingText(level) {
+    return this.ctcpCommand('TYPING', level);
   }
   decodeEntities(text) {
     text = text.replace(/&amp;/g, '&');
@@ -944,6 +973,9 @@ class IrcUser {
   }
   debugChannelEnabled() {
     return this.preferences.indexOf('debug-chan') !== -1;
+  }
+  typingNotificationsEnabled() {
+    return this.preferences.indexOf('typing-notifications') !== -1;
   }
   mapIrcToSlack(ircTarget, slackId) {
     let preSlackId = this.ircToSlack.get(ircTarget);

--- a/tests/test_ctcp.js
+++ b/tests/test_ctcp.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const test = require('tape');
+const mocks = require('./mocks');
+
+test('irc_ctcp_action', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.slackWeb.expect('chat.meMessage', {
+    channel: 'C1234CHAN1',
+    text: 'me',
+    as_user: true,
+    thread_ts: null,
+  }, {
+    ok: true,
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ '#test_chan_1', '\x01ACTION me\x01' ] });
+  t.end();
+});
+
+test('slack_me_message', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.ircSocket.expect(':test_slack_user PRIVMSG #test_chan_1 :\x01ACTION me\x01');
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'me',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+    subtype: 'me_message',
+  });
+  t.end();
+});
+
+test('slack_ctcp_typing_disabled', async(t) => {
+  t.plan(0 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  await c.daemon.onSlackUserTyping(c.ircUser, {
+    type: 'user_typing',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+  });
+  t.end();
+});
+
+test('slack_ctcp_typing_enabled', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.ircSocket.expect(':test_slack_user PRIVMSG #test_chan_1 :\x01TYPING 1\x01');
+  c.ircUser.preferences.push('typing-notifications');
+  await c.daemon.onSlackUserTyping(c.ircUser, {
+    type: 'user_typing',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+  });
+  t.end();
+});


### PR DESCRIPTION
To bridge between IRC and Slack, we rely on the CTCP TYPING command to
send and receive typing notifications.  As with all CTCP commands, these
messages are bundled in a PRIVMSG in the form:

    PRIVMSG \001TYPING LEVEL\001

where LEVEL is an integer (zero means stop typing and non-zero means
typing).

To handle sending user_typing events from the IRC client to Slack, the
server has a check in the onIrcPrivmsg handler for CTCP TYPING commands.
If the PRIVMSG message contains a CTCP TYPING command, the server calls
the sendTyping method of the SlackRtm object to notify Slack that the
specified user in the PRIVMSG is typing.

To handle receiving user_typing events from Slack, the server has a new
onSlackTyping handler which sends a CTCP TYPING command with the
specified user to the corresponding IRC channel.

To test the user_typing events, I used Weechat and the following script:

    https://gist.github.com/pbui/92b5a1b3bee87a95331d1f2d714f8f9c

With this new server extension and Weechat can both send typing
notifications and receive them.

Note: Slack does not have a mechanism for clearing typing state, so each
client must keep track of typing state and use some sort of timeout to
clear it as shown in the script above.