### PR TITLE
Implement presence monitoring

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -100,13 +100,17 @@ class Irslackd {
       [ 'subteam_created',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
       [ 'subteam_updated',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
       [ 'user_typing',           self.makeSlackHandler(self.onSlackUserTyping)          ],
+      [ 'presence_change',       self.makeSlackHandler(self.onSlackPresenceChange)      ],
+      [ 'team_join',             self.makeSlackHandler(self.onSlackTeamJoin)            ],
       [ 'slack_event',           self.makeSlackHandler(self.onSlackEvent)               ],
     ]).forEach((handler, event, map) => {
       ircUser.slackRtm.on(event, handler);
     });
 
     // Start RTM
-    ircUser.slackRtm.start();
+    ircUser.slackRtm.start({
+      batch_presence_aware: ircUser.presenceEnabled(),
+    });
   }
   async onIrcAway(ircUser, msg) {
     // if args is empty, unset away status
@@ -344,6 +348,9 @@ class Irslackd {
     } catch (e) {
       this.logError(ircUser, 'Failed refreshing workspace:' + util.inspect(e));
     }
+
+    // Update presence subscriptions
+    this.updatePresenceSubscriptions(ircUser);
   }
   async onSlackMessage(ircUser, event) {
     const self = this;
@@ -564,6 +571,35 @@ class Irslackd {
     let line = this.typingText('1');
     this.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ ircTarget, line ]);
   }
+  async onSlackPresenceChange(ircUser, event) {
+    if (!ircUser.presenceEnabled()) {
+      return;
+    }
+    let ircNick = await this.resolveSlackUser(ircUser, event.user);
+    let ircMode = null;
+    if (event.presence === 'away') {
+      ircUser.ircNickActive.delete(ircNick);
+      ircMode = '-v';
+    } else {
+      ircUser.ircNickActive.add(ircNick);
+      ircMode = '+v';
+    }
+    console.log('slack_presence_change', ircNick, event.presence);
+    ircUser.channelNicks.forEach((nicks, channel) => {
+      if (nicks.get(ircNick) && ircUser.isInChannel(channel)) {
+        this.ircd.write(ircUser.socket, 'irslackd', 'MODE', [channel, ircMode, ircNick]);
+      }
+    });
+  }
+  async onSlackTeamJoin(ircUser, event) {
+    // Add new member
+    let slackUser = event.user.id;
+    let ircNick = this.replaceIllegalIrcNickChars(event.user.name);
+    ircUser.mapIrcToSlack(ircNick, slackUser);
+
+    // Update presence subscriptions
+    this.updatePresenceSubscriptions(ircUser);
+  }
   async onIrcWho(ircUser, msg) {
     await this.onIrcWhois(ircUser, msg);
   }
@@ -716,7 +752,9 @@ class Irslackd {
         ircUser.ircNick,
         '=',
         ircChan,
-        ircNicks.slice(i, i + nickChunkSize).join(' '),
+        ircNicks.slice(i, i + nickChunkSize).map((ircNick) => {
+          return ircUser.ircNickActive.has(ircNick) ? '+' + ircNick : ircNick;
+        }).join(' '),
       ]);
     }
   }
@@ -725,6 +763,14 @@ class Irslackd {
     if (ircUser.partChannel(ircChan)) {
       this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [ ircChan ]);
     }
+  }
+  updatePresenceSubscriptions(ircUser) {
+    if (!ircUser.presenceEnabled()) {
+      return;
+    }
+    let userIds = ircUser.getAllSlackUserIds();
+    console.log('Subscribing to presence of', userIds.length, 'users');
+    ircUser.slackRtm.subscribePresence(userIds);
   }
   ctcpCommand(command, text) {
     return String.fromCharCode(1) + command + ' ' + text + String.fromCharCode(1);
@@ -938,6 +984,7 @@ class IrcUser {
     this.ircToSlack = new Map();
     this.slackToIrc = new Map();
     this.ircNickToSlackChanId = new Map();
+    this.ircNickActive = new Set();
     this.selfEchoList = [];
     this.selfEchoLock = new AwaitLock();
     this.typingTimer = null;
@@ -965,6 +1012,15 @@ class IrcUser {
   removeNickFromChannel(ircChan, ircNick) {
     return this.channelNicks.get(ircChan).delete(ircNick, true);
   }
+  getAllSlackUserIds() {
+    let userIds = [];
+    this.slackToIrc.forEach((ircNick, userId) => {
+      if (userId[0] === 'U') {
+        userIds.push(userId);
+      }
+    });
+    return userIds;
+  }
   reactionsEnabled() {
     return this.preferences.indexOf('no-reactions') === -1;
   }
@@ -976,6 +1032,9 @@ class IrcUser {
   }
   typingNotificationsEnabled() {
     return this.preferences.indexOf('typing-notifications') !== -1;
+  }
+  presenceEnabled() {
+    return this.preferences.indexOf('presence') !== -1;
   }
   mapIrcToSlack(ircTarget, slackId) {
     let preSlackId = this.ircToSlack.get(ircTarget);

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -71,6 +71,8 @@ class MockSlackRtmClient extends EventEmitter {
   }
   disconnect() {
   }
+  subscribePresence() {
+  }
 }
 
 async function connectOneIrcClient(t, prefs = []) {

--- a/tests/test_presence.js
+++ b/tests/test_presence.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const test = require('tape');
+const mocks = require('./mocks');
+
+test('slack_presence_change_noop', async(t) => {
+  t.plan(0 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  await c.daemon.onSlackPresenceChange(c.ircUser, {
+    type: 'presence_change',
+    presence: 'away',
+    user: 'U1234USER',
+  });
+  await c.daemon.onSlackPresenceChange(c.ircUser, {
+    type: 'presence_change',
+    presence: 'active',
+    user: 'U1234USER',
+  });
+  t.end();
+});
+
+test('slack_presence_change_away', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t, ['presence']);
+  c.ircSocket.expect(':irslackd MODE #test_chan_1 -v test_slack_user');
+  await c.daemon.onSlackPresenceChange(c.ircUser, {
+    type: 'presence_change',
+    presence: 'away',
+    user: 'U1234USER',
+  });
+  t.end();
+});
+
+test('slack_presence_change_active', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t, ['presence']);
+  c.ircSocket.expect(':irslackd MODE #test_chan_1 +v test_slack_user');
+  await c.daemon.onSlackPresenceChange(c.ircUser, {
+    type: 'presence_change',
+    presence: 'active',
+    user: 'U1234USER',
+  });
+  t.end();
+});


### PR DESCRIPTION
This feature implements a crude form of user presence by using the CHAN
MODE IRC command to denote if a user is active (+v / voiced) or away (-v
/ devoiced).  The use of voice and devoice to denote presence is based
on how bitlbee communicates status in its IRC bridge.

- To receive presence updates, we must subscribe to each user we are
interested in; unfortunately there is no way to know which channel the
IRC user is viewing, so we simply subscribe to all users.  This
exhaustive approach is expensive, but it is infrequent.

- Likewise, to communicate a change in user presence, we must send a
CHAN MODE command to each channel the user is in.  Again this is
expensive, but it is infrequent and the only way since IRC does not
directly support the concept of user presence.

- No additional bookkeeping is required since the ircUser class already
keeps track of all users in its channelNicks member.

- Currently, although batch_presence_aware is set, it appears to do
nothing (presence updates still occur one user at a time).

- On start up, there is a huge flood of traffic since the Slack server
will send updates for many (if not all) of the users (and the bridge
will then send CHAN MODE commands).

- This feature is disabled by default and is only enabled by the
"presence" password argument (sent by the IRC client after the Slack
token).