### PR TITLE
/who feature

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const util      = require('util');
-const slack     = require('@slack/client');
+const util = require('util');
+const slack = require('@slack/client');
 const AwaitLock = require('await-lock');
-const ircd      = require('./ircd');
-const refresh   = require('./slack-refresh');
+const ircd = require('./ircd');
+const refresh = require('./slack-refresh');
 const debugChannel = '+irslackd';
 
 class Irslackd {
@@ -19,24 +19,24 @@ class Irslackd {
     const self = this;
     self.ircd = self.getNewIrcd(self.config.tlsOpts);
     new Map([
-      [ 'AWAY',       self.makeIrcHandler(self.onIrcAway)     ],
-      [ 'JOIN',       self.makeIrcHandler(self.onIrcJoin)     ],
-      [ 'NICK',       self.makeIrcHandler(self.onIrcNick)     ],
-      [ 'PART',       self.makeIrcHandler(self.onIrcPart)     ],
-      [ 'PASS',       self.makeIrcHandler(self.onIrcPass)     ],
-      [ 'PRIVMSG',    self.makeIrcHandler(self.onIrcPrivmsg)  ],
-      [ 'QUIT',       self.makeIrcHandler(self.onIrcQuit)     ],
-      [ 'USER',       self.makeIrcHandler(self.onIrcUser)     ],
-      [ 'INVITE',     self.makeIrcHandler(self.onIrcInvite)   ],
-      [ 'WHO',        self.makeIrcHandler(self.onIrcWho)      ],
-      [ 'WHOIS',      self.makeIrcHandler(self.onIrcWhois)    ],
-      [ 'PING',       self.makeIrcHandler(self.onIrcPing)     ],
-      [ 'MODE',       self.makeIrcHandler(self.onIrcMode)     ],
-      [ 'LIST',       self.makeIrcHandler(self.onIrcList)     ],
-      [ 'ircLine',    self.makeIrcHandler(self.onIrcLine)     ],
-      [ 'ircError',   self.makeIrcHandler(self.onIrcError)    ],
-      [ 'ircClose',   self.makeIrcHandler(self.onIrcClose)    ],
-      [ 'ircConnect', (socket) => { self.onIrcConnect(socket); } ],
+      ['AWAY', self.makeIrcHandler(self.onIrcAway)],
+      ['JOIN', self.makeIrcHandler(self.onIrcJoin)],
+      ['NICK', self.makeIrcHandler(self.onIrcNick)],
+      ['PART', self.makeIrcHandler(self.onIrcPart)],
+      ['PASS', self.makeIrcHandler(self.onIrcPass)],
+      ['PRIVMSG', self.makeIrcHandler(self.onIrcPrivmsg)],
+      ['QUIT', self.makeIrcHandler(self.onIrcQuit)],
+      ['USER', self.makeIrcHandler(self.onIrcUser)],
+      ['INVITE', self.makeIrcHandler(self.onIrcInvite)],
+      ['WHO', self.makeIrcHandler(self.onIrcWho)],
+      ['WHOIS', self.makeIrcHandler(self.onIrcWhois)],
+      ['PING', self.makeIrcHandler(self.onIrcPing)],
+      ['MODE', self.makeIrcHandler(self.onIrcMode)],
+      ['LIST', self.makeIrcHandler(self.onIrcList)],
+      ['ircLine', self.makeIrcHandler(self.onIrcLine)],
+      ['ircError', self.makeIrcHandler(self.onIrcError)],
+      ['ircClose', self.makeIrcHandler(self.onIrcClose)],
+      ['ircConnect', (socket) => { self.onIrcConnect(socket); }],
     ]).forEach((handler, cmd, map) => {
       self.ircd.on(cmd, handler);
     });
@@ -86,24 +86,24 @@ class Irslackd {
     // Setup Slack handlers
     self.rtmMap.set(ircUser.slackRtm, ircUser);
     new Map([
-      [ 'ready',                 self.makeSlackHandler(self.onSlackReady)               ],
-      [ 'message',               self.makeSlackHandler(self.onSlackMessage)             ],
-      [ 'channel_joined',        self.makeSlackHandler(self.onSlackChannelJoined)       ],
-      [ 'channel_left',          self.makeSlackHandler(self.onSlackChannelLeft)         ],
-      [ 'channel_rename',        self.makeSlackHandler(self.onSlackChannelRename)       ],
-      [ 'channel_created',       self.makeSlackHandler(self.onSlackChannelCreated)      ],
-      [ 'member_joined_channel', self.makeSlackHandler(self.onSlackMemberJoinedChannel) ],
-      [ 'member_left_channel',   self.makeSlackHandler(self.onSlackMemberLeftChannel)   ],
-      [ 'mpim_open',             self.makeSlackHandler(self.onSlackMpimOpen)            ],
-      [ 'mpim_close',            self.makeSlackHandler(self.onSlackMpimClose)           ],
-      [ 'reaction_added',        self.makeSlackHandler(self.onSlackReactionAdded)       ],
-      [ 'reaction_removed',      self.makeSlackHandler(self.onSlackReactionRemoved)     ],
-      [ 'subteam_created',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
-      [ 'subteam_updated',       self.makeSlackHandler(self.onSlackSubteamUpdated)      ],
-      [ 'user_typing',           self.makeSlackHandler(self.onSlackUserTyping)          ],
-      [ 'presence_change',       self.makeSlackHandler(self.onSlackPresenceChange)      ],
-      [ 'team_join',             self.makeSlackHandler(self.onSlackTeamJoin)            ],
-      [ 'slack_event',           self.makeSlackHandler(self.onSlackEvent)               ],
+      ['ready', self.makeSlackHandler(self.onSlackReady)],
+      ['message', self.makeSlackHandler(self.onSlackMessage)],
+      ['channel_joined', self.makeSlackHandler(self.onSlackChannelJoined)],
+      ['channel_left', self.makeSlackHandler(self.onSlackChannelLeft)],
+      ['channel_rename', self.makeSlackHandler(self.onSlackChannelRename)],
+      ['channel_created', self.makeSlackHandler(self.onSlackChannelCreated)],
+      ['member_joined_channel', self.makeSlackHandler(self.onSlackMemberJoinedChannel)],
+      ['member_left_channel', self.makeSlackHandler(self.onSlackMemberLeftChannel)],
+      ['mpim_open', self.makeSlackHandler(self.onSlackMpimOpen)],
+      ['mpim_close', self.makeSlackHandler(self.onSlackMpimClose)],
+      ['reaction_added', self.makeSlackHandler(self.onSlackReactionAdded)],
+      ['reaction_removed', self.makeSlackHandler(self.onSlackReactionRemoved)],
+      ['subteam_created', self.makeSlackHandler(self.onSlackSubteamUpdated)],
+      ['subteam_updated', self.makeSlackHandler(self.onSlackSubteamUpdated)],
+      ['user_typing', self.makeSlackHandler(self.onSlackUserTyping)],
+      ['presence_change', self.makeSlackHandler(self.onSlackPresenceChange)],
+      ['team_join', self.makeSlackHandler(self.onSlackTeamJoin)],
+      ['slack_event', self.makeSlackHandler(self.onSlackEvent)],
     ]).forEach((handler, event, map) => {
       ircUser.slackRtm.on(event, handler);
     });
@@ -192,7 +192,7 @@ class Irslackd {
     });
 
     // Assemble IRC nicks
-    let ircNicks = [ ircUser.ircNick ];
+    let ircNicks = [ircUser.ircNick];
     let ircNickPromises = [];
     members.members.forEach((userId) => {
       let ircNickPromise = self.resolveSlackUser(ircUser, userId);
@@ -300,7 +300,7 @@ class Irslackd {
   }
   async onIrcPing(ircUser, msg) {
     // Send PONG
-    this.ircd.write(ircUser.socket, 'irslackd', 'PONG', [ 'irslackd' ]);
+    this.ircd.write(ircUser.socket, 'irslackd', 'PONG', ['irslackd']);
   }
   async onIrcMode(ircUser, msg) {
     let target = msg.args[0];
@@ -308,15 +308,10 @@ class Irslackd {
       this.ircd.write(ircUser.socket, 'irslackd', 'MODE', msg.args);
     }
   }
-  /**
-   * @todo: work in progress
-   * @param {*} ircUser 
-   * @param {*} msg 
-   */
   async onIrcInvite(ircUser, msg) {
     const self = this;
     if (msg.args.length !== 2) {
-      self.ircd.write(ircUser.socket, 'irslackd', '371', [ ircUser.ircNick, ':Must pass two params, the user to invite and the channel' ]);
+      self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Must pass two params, the user to invite and the channel']);
       return; // must have two params (nick and channel)
     }
     var userId = await self.lookupUserId(ircUser, msg.args[0]);
@@ -328,7 +323,7 @@ class Irslackd {
     self.ircd.write(ircUser.socket, 'irslackd', '341', [
       ircUser.ircNick,
       channelId,
-      userId, 
+      userId,
     ]);
   }
   async lookupChannelId(ircUser, channelName) {
@@ -372,17 +367,16 @@ class Irslackd {
   }
   async onIrcWho(ircUser, msg) {
     const self = this;
-    var userSearch, channelSearch;
+    var userSearch;
     if (msg.args.length > 1) return; // Only support `WHO` with one params
-    if (msg.args.length > 0 && msg.args[0].substr(0,1) === '#') {
-      channelSearch = msg.args[0].substr(1);
-      self.ircd.write(ircUser.socket, 'irslackd', '315', [ ircUser.ircNick, ':End of WHO - channels not implemented' ]);
+    if (msg.args.length > 0 && msg.args[0].substr(0, 1) === '#') {
+      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO - channels not implemented']);
       return;
     }
     if (msg.args.length > 0) {
       userSearch = msg.args[0];
     }
-    self.ircd.write(ircUser.socket, 'irslackd', '371', [ ircUser.ircNick, ':Start of WHO' ]);
+    self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Start of WHO']);
     let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
       presence: false,
       limit: 1000,
@@ -404,13 +398,13 @@ class Irslackd {
           'irslackd',
           'example.com',
           user.name,
-          user.profile.email?user.profile.email:'nobody@example.com',
+          user.profile.email ? user.profile.email : 'nobody@example.com',
           '0',
           user.profile.real_name,
         ]);
       }
     });
-    self.ircd.write(ircUser.socket, 'irslackd', '315', [ ircUser.ircNick, ':End of WHO' ]);
+    self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO']);
   }
   async onIrcList(ircUser, msg) {
     const self = this;
@@ -428,17 +422,17 @@ class Irslackd {
         ':' + channel.topic.value,
       ]);
     });
-    self.ircd.write(ircUser.socket, 'irslackd', '323', [ ircUser.ircNick, ':End of LIST' ]);
+    self.ircd.write(ircUser.socket, 'irslackd', '323', [ircUser.ircNick, ':End of LIST']);
   }
   async onIrcQuit(ircUser, msg) {
     // Close link
-    this.ircd.write(ircUser.socket, 'irslackd', 'ERROR', [ ':Closing Link' ]);
+    this.ircd.write(ircUser.socket, 'irslackd', 'ERROR', [':Closing Link']);
     ircUser.socket.destroy();
   }
   async onSlackReady(ircUser, event) {
     // Send MOTD
-    this.ircd.write(ircUser.socket, 'irslackd', '001', [ ircUser.ircNick, 'irslackd' ]);
-    this.ircd.write(ircUser.socket, 'irslackd', '376', [ ircUser.ircNick, 'End of MOTD' ]);
+    this.ircd.write(ircUser.socket, 'irslackd', '001', [ircUser.ircNick, 'irslackd']);
+    this.ircd.write(ircUser.socket, 'irslackd', '376', [ircUser.ircNick, 'End of MOTD']);
 
     // set user presence to auto instead of away
     await this.setSlackPresence(ircUser, true);
@@ -532,7 +526,7 @@ class Irslackd {
     }
 
     // Also send attachments
-    let messages = [ event.text ];
+    let messages = [event.text];
     if (event.attachments) {
       event.attachments.forEach((attachment, idx) => {
         if (attachment.fallback) messages.push('> ' + self.ircizeText(ircUser, self.decodeEntities(attachment.fallback)));
@@ -553,7 +547,7 @@ class Irslackd {
         line = line.trim();
         if (line.length < 1) return;
         if (event.subtype === 'me_message') line = self.meText(line);
-        self.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ ircTarget, ':' + line ]);
+        self.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ircTarget, ':' + line]);
       });
     });
   }
@@ -566,7 +560,7 @@ class Irslackd {
     event.topic = this.ircizeText(ircUser, this.decodeEntities(event.topic));
 
     // Send topic message
-    this.ircd.write(ircUser.socket, ircNick, 'TOPIC', [ ircChan, event.topic ]);
+    this.ircd.write(ircUser.socket, ircNick, 'TOPIC', [ircChan, event.topic]);
   }
   async onSlackChannelJoined(ircUser, event) {
     let ircChan = await this.resolveSlackChannel(ircUser, event.channel);
@@ -577,7 +571,7 @@ class Irslackd {
   async onSlackChannelLeft(ircUser, event) {
     let ircChan = await this.resolveSlackChannel(ircUser, event.channel);
     if (ircChan) {
-      await this.onIrcPart(ircUser, { args: [ ircChan ] }, event.channel);
+      await this.onIrcPart(ircUser, { args: [ircChan] }, event.channel);
     }
   }
   async onSlackChannelRename(ircUser, event) {
@@ -585,7 +579,7 @@ class Irslackd {
     let newIrcChan = '#' + event.channel.name;
     let isInChan = ircUser.isInChannel(oldIrcChan);
     if (isInChan) {
-      this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [ oldIrcChan ]);
+      this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [oldIrcChan]);
       ircUser.partChannel(oldIrcChan);
     }
     ircUser.ircToSlack.delete(oldIrcChan);
@@ -600,7 +594,7 @@ class Irslackd {
     let [ircNick, ircChan] = await this.resolveSlackTarget(ircUser, event);
     if (ircNick && ircChan && !ircUser.isNickInChannel(ircChan, ircNick)) {
       ircUser.addNickToChannel(ircChan, ircNick);
-      this.ircd.write(ircUser.socket, ircNick, 'JOIN', [ ircChan ]);
+      this.ircd.write(ircUser.socket, ircNick, 'JOIN', [ircChan]);
     }
   }
   async onSlackMemberLeftChannel(ircUser, event) {
@@ -608,7 +602,7 @@ class Irslackd {
     let [ircNick, ircChan] = await this.resolveSlackTarget(ircUser, event);
     if (ircNick && ircChan && ircUser.isNickInChannel(ircChan, ircNick)) {
       ircUser.removeNickFromChannel(ircChan, ircNick);
-      this.ircd.write(ircUser.socket, ircNick, 'PART', [ ircChan ]);
+      this.ircd.write(ircUser.socket, ircNick, 'PART', [ircChan]);
     }
   }
   async onSlackMpimOpen(ircUser, event) {
@@ -648,11 +642,11 @@ class Irslackd {
     }
     let ircReacter = this.resolveSlackUser(ircUser, event.user);
     let ircReactee = this.resolveSlackUser(ircUser, event.item_user);
-    let ircChan    = this.resolveSlackChannel(ircUser, event.item.channel);
+    let ircChan = this.resolveSlackChannel(ircUser, event.item.channel);
     try {
       ircReacter = await ircReacter;
       ircReactee = await ircReactee;
-      ircChan    = await ircChan;
+      ircChan = await ircChan;
       if (!ircReacter || !ircReactee || !ircChan) {
         throw Error('Missing reaction info');
       }
@@ -661,7 +655,7 @@ class Irslackd {
       return;
     }
     let message = this.meText(verb + ' @ ' + ircReactee + ' :' + event.reaction + ':');
-    this.ircd.write(ircUser.socket, ircReacter, 'PRIVMSG', [ ircChan, message ]);
+    this.ircd.write(ircUser.socket, ircReacter, 'PRIVMSG', [ircChan, message]);
   }
   async onSlackUserTyping(ircUser, event) {
     if (!ircUser.typingNotificationsEnabled()) {
@@ -674,7 +668,7 @@ class Irslackd {
     }
     console.log('slack_typing', ircNick, ircTarget);
     let line = this.typingText('1');
-    this.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ ircTarget, line ]);
+    this.ircd.write(ircUser.socket, ircNick, 'PRIVMSG', [ircTarget, line]);
   }
   async onSlackPresenceChange(ircUser, event) {
     if (!ircUser.presenceEnabled()) {
@@ -705,9 +699,9 @@ class Irslackd {
     // Update presence subscriptions
     this.updatePresenceSubscriptions(ircUser);
   }
-/**  async onIrcWho(ircUser, msg) {
-    await this.onIrcWhois(ircUser, msg);
-  }*/
+  /**  async onIrcWho(ircUser, msg) {
+      await this.onIrcWhois(ircUser, msg);
+    }*/
   async onIrcWhois(ircUser, msg) {
     if (msg.args.length < 1) return;
     let ircNick = msg.args[0];
@@ -739,15 +733,15 @@ class Irslackd {
     let out = null;
     const iOpts = { depth: 3, showHidden: true };
     switch (cmd) {
-      case 'dump_server': out = util.inspect(this, iOpts);             break;
-      case 'dump_user':   out = util.inspect(ircUser, iOpts);          break;
-      case 'dump_rtm':    out = util.inspect(ircUser.slackRtm, iOpts); break;
-      case 'dump_web':    out = util.inspect(ircUser.slackWeb, iOpts); break;
+      case 'dump_server': out = util.inspect(this, iOpts); break;
+      case 'dump_user': out = util.inspect(ircUser, iOpts); break;
+      case 'dump_rtm': out = util.inspect(ircUser.slackRtm, iOpts); break;
+      case 'dump_web': out = util.inspect(ircUser.slackWeb, iOpts); break;
     }
     if (out) console.log('debug', cmd, out);
   }
   onIrcDebugJoin(ircUser) {
-    this.sendIrcChannelJoin(ircUser, debugChannel, 'irslackd debug', [ ircUser.ircNick ]);
+    this.sendIrcChannelJoin(ircUser, debugChannel, 'irslackd debug', [ircUser.ircNick]);
   }
   onIrcDebugPart(ircUser) {
     this.sendIrcChannelPart(ircUser, debugChannel);
@@ -788,7 +782,7 @@ class Irslackd {
     } catch (e) {
       this.logError(ircUser, util.inspect(e));
     }
-    return [ ircNick, ircChan ];
+    return [ircNick, ircChan];
   }
   async resolveSlackChannel(ircUser, slackChan) {
     // Check cache
@@ -864,10 +858,10 @@ class Irslackd {
     ircUser.joinChannel(ircChan, ircNicks);
 
     // Join IRC channel
-    this.ircd.write(ircUser.socket, ircUser.ircNick, 'JOIN', [ ircChan ]);
+    this.ircd.write(ircUser.socket, ircUser.ircNick, 'JOIN', [ircChan]);
     if (topic) {
       topic = this.ircizeText(ircUser, this.decodeEntities(topic));
-      this.ircd.write(ircUser.socket, 'irslackd', '332', [ ircUser.ircNick, ircChan, ':' + topic ]);
+      this.ircd.write(ircUser.socket, 'irslackd', '332', [ircUser.ircNick, ircChan, ':' + topic]);
     }
 
     // Send nicks in chunks of 20
@@ -886,7 +880,7 @@ class Irslackd {
   sendIrcChannelPart(ircUser, ircChan) {
     // Unset channel marker and leave IRC channel
     if (ircUser.partChannel(ircChan)) {
-      this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [ ircChan ]);
+      this.ircd.write(ircUser.socket, ircUser.ircNick, 'PART', [ircChan]);
     }
   }
   updatePresenceSubscriptions(ircUser) {
@@ -967,9 +961,9 @@ class Irslackd {
     let re = /^@thread-([^ ]+) /;
     let match = re.exec(text);
     if (match) {
-      return [ text.replace(re, ''), match[1] ];
+      return [text.replace(re, ''), match[1]];
     }
-    return [ text, null ];
+    return [text, null];
   }
   async rememberSelfEcho(ircUser, message, apiCb) {
     await ircUser.selfEchoLock.acquireAsync();
@@ -1069,8 +1063,8 @@ class Irslackd {
         results[aggKey] = results[aggKey].concat(result[aggKey]);
       }
       if (!result.response_metadata
-         || !result.response_metadata.next_cursor
-         || result.response_metadata.next_cursor.length < 1
+        || !result.response_metadata.next_cursor
+        || result.response_metadata.next_cursor.length < 1
       ) {
         break;
       }

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -388,8 +388,8 @@ class Irslackd {
           var slackId = ircUser.ircToSlack.get(ircNickId);
           if (typeof slackId === 'undefined') throw Error('Could not find ircNickId, ' + ircNickId + ', in ircToSlack');
           // cache may not have been filled yet ...
-          await ircUser.mapSlackUser(ircNickId, slackId);
-          var slackInfo = ircUser.slackUsersInfo.get(slackId);
+          var slackInfo = await ircUser.mapSlackUser(ircNickId, slackId);
+          // var slackInfo = ircUser.slackUsersInfo.get(slackId);
           if (typeof slackInfo === 'undefined') {
             throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');
           }
@@ -416,8 +416,8 @@ class Irslackd {
           var writeit = false;
           var slackInfo;
           if (ircNickId.substr(0, 1) !== '#' && ircNickId.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
-            await ircUser.mapSlackUser(ircNickId, slackId);
-            slackInfo = ircUser.slackUsersInfo.get(slackId);
+            slackInfo = await ircUser.mapSlackUser(ircNickId, slackId);
+            // slackInfo = ircUser.slackUsersInfo.get(slackId);
             writeit = true;
           }
           if (writeit) {
@@ -1251,15 +1251,17 @@ class IrcUser {
     }
     this.ircToSlack.set(ircTarget, slackId);
     this.slackToIrc.set(slackId, ircTarget);
-    this.mapSlackUser(ircTarget, slackId);
+    // this.mapSlackUser(ircTarget, slackId);
   }
   async mapSlackUser(ircTarget, slackId) {
     if (ircTarget.substr(0, 1) === '#') return;
-    if (this.slackUsersInfo.get(slackId)) return; // no need to populate the user, he's already cached
-    var user = await this.slackWeb.paginateCallOrThrow('users.info', 'user', {
-      user: slackId,
-    });
-    this.slackUsersInfo.set(slackId, user);
+    if (!this.slackUsersInfo.get(slackId)) {
+      var user = await this.slackWeb.paginateCallOrThrow('users.info', 'user', {
+        user: slackId,
+      });
+      this.slackUsersInfo.set(slackId, user);
+    }
+    return this.slackUsersInfo.get(slackId);
   }
 }
 

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -338,11 +338,11 @@ class Irslackd {
         channelId,
       ]);
     } catch (e) {
-      console.debug('invite call failed response: ' + JSON.stringify(e.message));
+      var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
       self.ircd.write(ircUser.socket, 'irslackd', '371', [
         ircUser.ircNick, ':/INVITE failed->' +
         JSON.parse(e.message).error.code + '->' +
-        JSON.parse(e.message).error.data.error,
+        errorFromData,
       ]);
     }
   }

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -365,7 +365,7 @@ class Irslackd {
     const self = this;
     try {
       var userSearch, chanSearch;
-      if (msg.args.length > 1) {
+      if (msg.args.length !== 1) {
         throw Error('/WHO only supports one parameter');
       }
       if (msg.args.length > 0 && msg.args[0].substr(0, 1) === '#') {
@@ -379,12 +379,12 @@ class Irslackd {
         if (typeof nicksInChan === 'undefined') {
           throw new Error('Unknown channel ' + chanSearch);
         }
-        var itemsProcessed = nicksInChan.length;
-        nicksInChan.forEach(async(value, key) => {
-          var slackId = ircUser.ircToSlack.get(key);
-          if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
+        var nicksInChanProcessed = nicksInChan.size;
+        nicksInChan.forEach(async(value, ircNickId) => {
+          var slackId = ircUser.ircToSlack.get(ircNickId);
+          if (typeof slackId === 'undefined') throw Error('Could not find ircNickId, ' + ircNickId + ', in ircToSlack');
           // cache may not have been filled yet ...
-          await ircUser.mapSlackUser(key, slackId);
+          await ircUser.mapSlackUser(ircNickId, slackId);
           var slackInfo = ircUser.slackUsersInfo.get(slackId);
           if (typeof slackInfo === 'undefined') {
             throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');
@@ -396,25 +396,24 @@ class Irslackd {
             'irslackd', // host
             'example.com', // server
             slackInfo.user.name, // nick
-            'H',
+            ircUser.ircNickActive.has(ircNickId) ? 'H' : 'G',
             ':0 ' +
             (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
           ]);
-          itemsProcessed -= 1;
-          if (itemsProcessed === 0) () => {
-            self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
-          };
+          nicksInChanProcessed -= 1;
+          if (nicksInChanProcessed === 0) {
+            self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, chanSearch, ':End of WHO list']);
+          }
         });
       } else {
-        ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
-          // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
+        var ircToSlackProcessed = ircUser.ircToSlack.size;
+        console.debug('ircToSlackProcessed: ' + ircToSlackProcessed);
+        ircUser.ircToSlack.forEach(async(slackId, ircNickId, theMap) => {
           var writeit = false;
-          if (userSearch) {
-            if (typeof slackInfo.user === 'undefined') throw Error('slackInfo user was not populated');
-            if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
-              writeit = true;
-            }
-          } else {
+          var slackInfo;
+          if (ircNickId.substr(0, 1) !== '#' && ircNickId.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
+            await ircUser.mapSlackUser(ircNickId, slackId);
+            slackInfo = ircUser.slackUsersInfo.get(slackId);
             writeit = true;
           }
           if (writeit) {
@@ -425,13 +424,16 @@ class Irslackd {
               'irslackd', // host
               'example.com', // server
               slackInfo.user.name, // nick
-              'H',
+              ircUser.ircNickActive.has(ircNickId) ? 'H' : 'G',
               ':0 ' +
               (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
             ]);
           }
+          ircToSlackProcessed -= 1;
+          if (ircToSlackProcessed === 0) {
+            self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
+          }
         });
-        self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
       }
     } catch (e) {
       var message;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -372,7 +372,7 @@ class Irslackd {
     if (msg.args.length > 0) {
       userSearch = msg.args[0];
     }
-    self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Start of WHO']);
+    // self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Start of WHO']);
     let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
       presence: false,
       limit: 1000,
@@ -396,7 +396,7 @@ class Irslackd {
           user.name,
           user.profile.email ? user.profile.email : 'nobody@example.com',
           '0',
-          user.profile.real_name,
+          user.profile.real_name ? user.profile.real_name : 'Nobody',
         ]);
       }
     });
@@ -699,9 +699,6 @@ class Irslackd {
     // Update presence subscriptions
     this.updatePresenceSubscriptions(ircUser);
   }
-  /**  async onIrcWho(ircUser, msg) {
-      await this.onIrcWhois(ircUser, msg);
-    }*/
   async onIrcWhois(ircUser, msg) {
     if (msg.args.length < 1) return;
     let ircNick = msg.args[0];

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -376,29 +376,28 @@ class Irslackd {
       }
       if (chanSearch) {
         var nicksInChan = ircUser.channelNicks.get(chanSearch);
-        console.debug(nicksInChan);
+        if (typeof nicksInChan === 'undefined') {
+          throw new Error('Unknown channel ' + chanSearch);
+        }
         nicksInChan.forEach((value, key) => {
-          console.debug('key / value: ' + key + '/' + value);
           var slackId = ircUser.ircToSlack.get(key);
-          console.debug('slackid: ' + slackId);
           var slackInfo = ircUser.slackUsersInfo.get(slackId);
-          console.debug('slackinfo: ' + slackInfo);
           self.ircd.write(ircUser.socket, 'irslackd', '352', [
             ircUser.ircNick,
-            '*',
-            slackInfo.user.id,
-            'irslackd',
-            'example.com',
-            slackInfo.user.name,
-            slackInfo.user.profile.email ? slackInfo.user.profile.email : 'nobody@example.com',
-            '0',
-            slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody',
+            chanSearch, // channel
+            slackInfo.user.id, // user
+            'irslackd', // host
+            'example.com', // server
+            slackInfo.user.name, // nick
+            'H',
+            ':0 ' +
+            (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
           ]);
 
         });
       } else {
         ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
-        // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
+          // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
           var writeit = false;
           if (userSearch) {
             if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
@@ -410,19 +409,19 @@ class Irslackd {
           if (writeit) {
             self.ircd.write(ircUser.socket, 'irslackd', '352', [
               ircUser.ircNick,
-              '*',
-              slackInfo.user.id,
-              'irslackd',
-              'example.com',
-              slackInfo.user.name,
-              slackInfo.user.profile.email ? slackInfo.user.profile.email : 'nobody@example.com',
-              '0',
-              slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody',
+              '#', // channel
+              slackInfo.user.id, // user
+              'irslackd', // host
+              'example.com', // server
+              slackInfo.user.name, // nick
+              'H',
+              ':0 ' +
+              (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
             ]);
           }
         });
       }
-      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO']);
+      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
     } catch (e) {
       var message;
       if (this.isJson(e.message)) {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -19,22 +19,23 @@ class Irslackd {
     const self = this;
     self.ircd = self.getNewIrcd(self.config.tlsOpts);
     new Map([
-      [ 'AWAY',       self.makeIrcHandler(self.onIrcAway)    ],
-      [ 'JOIN',       self.makeIrcHandler(self.onIrcJoin)    ],
-      [ 'NICK',       self.makeIrcHandler(self.onIrcNick)    ],
-      [ 'PART',       self.makeIrcHandler(self.onIrcPart)    ],
-      [ 'PASS',       self.makeIrcHandler(self.onIrcPass)    ],
-      [ 'PRIVMSG',    self.makeIrcHandler(self.onIrcPrivmsg) ],
-      [ 'QUIT',       self.makeIrcHandler(self.onIrcQuit)    ],
-      [ 'USER',       self.makeIrcHandler(self.onIrcUser)    ],
-      [ 'WHO',        self.makeIrcHandler(self.onIrcWho)     ],
-      [ 'WHOIS',      self.makeIrcHandler(self.onIrcWhois)   ],
-      [ 'PING',       self.makeIrcHandler(self.onIrcPing)    ],
-      [ 'MODE',       self.makeIrcHandler(self.onIrcMode)    ],
-      [ 'LIST',       self.makeIrcHandler(self.onIrcList)    ],
-      [ 'ircLine',    self.makeIrcHandler(self.onIrcLine)    ],
-      [ 'ircError',   self.makeIrcHandler(self.onIrcError)   ],
-      [ 'ircClose',   self.makeIrcHandler(self.onIrcClose)   ],
+      [ 'AWAY',       self.makeIrcHandler(self.onIrcAway)     ],
+      [ 'JOIN',       self.makeIrcHandler(self.onIrcJoin)     ],
+      [ 'NICK',       self.makeIrcHandler(self.onIrcNick)     ],
+      [ 'PART',       self.makeIrcHandler(self.onIrcPart)     ],
+      [ 'PASS',       self.makeIrcHandler(self.onIrcPass)     ],
+      [ 'PRIVMSG',    self.makeIrcHandler(self.onIrcPrivmsg)  ],
+      [ 'QUIT',       self.makeIrcHandler(self.onIrcQuit)     ],
+      [ 'USER',       self.makeIrcHandler(self.onIrcUser)     ],
+      [ 'WHO',        self.makeIrcHandler(self.onIrcWho)      ],
+      [ 'WHOIS',      self.makeIrcHandler(self.onIrcWhois)    ],
+      [ 'PING',       self.makeIrcHandler(self.onIrcPing)     ],
+      [ 'MODE',       self.makeIrcHandler(self.onIrcMode)     ],
+      [ 'LIST',       self.makeIrcHandler(self.onIrcList)     ],
+      [ 'LUSERS',     self.makeIrcHandler(self.onIrcListUsers)],
+      [ 'ircLine',    self.makeIrcHandler(self.onIrcLine)     ],
+      [ 'ircError',   self.makeIrcHandler(self.onIrcError)    ],
+      [ 'ircClose',   self.makeIrcHandler(self.onIrcClose)    ],
       [ 'ircConnect', (socket) => { self.onIrcConnect(socket); } ],
     ]).forEach((handler, cmd, map) => {
       self.ircd.on(cmd, handler);
@@ -306,6 +307,38 @@ class Irslackd {
     if (target.substr(0, 1) === '#') {
       this.ircd.write(ircUser.socket, 'irslackd', 'MODE', [ target ]);
     }
+  }
+  async onIrcListUsers(ircUser, msg) {
+    const self = this;
+    var userSearch;
+    if (msg.args.length > 1) return; // Only support `LUSERS` with one params
+    if (msg.args.length > 0) {
+      userSearch = msg.args[0];
+    }
+    self.ircd.write(ircUser.socket, 'irslackd', '323', [ ircUser.ircNick, ':Start of LUSERS' ]);
+    let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
+      presence: false,
+      limit: 1000,
+    });
+    users.members.forEach((user) => {
+      var writeit = false;
+      if (userSearch) {
+        if (user.name.toLowerCase().toLowerCase().indexOf(userSearch.toLowerCase()) > 0) {
+          writeit = true;
+        }
+      } else {
+        writeit = true;
+      }
+      if (writeit) {
+        self.ircd.write(ircUser.socket, 'irslackd', '323', [
+          ircUser.ircNick,
+          '@' + user.name,
+          user.id,
+          user.profile.real_name,
+        ]);
+      }
+    });
+    self.ircd.write(ircUser.socket, 'irslackd', '323', [ ircUser.ircNick, ':End of LUSERS' ]);
   }
   async onIrcList(ircUser, msg) {
     const self = this;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -325,7 +325,9 @@ class Irslackd {
         throw Error('Must pass two params, the user to invite and the channel');
       }
       var ircChannel = msg.args[1];
-      var ircUserToInvite = msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0];
+      // adsr: Checking for leading `'@'` on usernames might be a cool feature but I'd rather make that change for all commands at once rather than having support for it only for `/invite`
+      // var ircUserToInvite = msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0];
+      var ircUserToInvite = msg.args[0];
       var userId = ircUser.ircToSlack.get(ircUserToInvite);
       var channelId = ircUser.ircToSlack.get(ircChannel);
       if (!userId) throw Error('IRC nick not found in irslackd cache');

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1238,6 +1238,7 @@ class IrcUser {
   }
   async mapSlackUser(ircTarget, slackId) {
     if (ircTarget.substr(0, 1) === '#') return;
+    if (this.slackUsersInfo.get(slackId)) return; // no need to populate the user, he's already cached
     var user = await this.slackWeb.paginateCallOrThrow('users.info', 'user', {
       user: slackId,
     });

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -382,9 +382,9 @@ class Irslackd {
         nicksInChan.forEach((value, key) => {
           try {
             var slackId = ircUser.ircToSlack.get(key);
-            if (typeof slackId === 'undefined') throw Error('Cloud not find slackId in ircToSlack');
+            if (typeof slackId === 'undefined') throw Error('Cloud not find slackId,' + key + ', in ircToSlack');
             var slackInfo = ircUser.slackUsersInfo.get(slackId);
-            if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId in slackUsersInfo');
+            if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId,' + slackId + ', in slackUsersInfo');
             self.ircd.write(ircUser.socket, 'irslackd', '352', [
               ircUser.ircNick,
               chanSearch, // channel

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -326,11 +326,10 @@ class Irslackd {
       }
       var userId = ircUser.ircToSlack.get(msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]);
       var channelId = ircUser.ircToSlack.get(msg.args[1]);
-      var result = await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
+      await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
         users: userId,
         channel: channelId,
       });
-      console.debug('invite call response: ' + JSON.stringify(result));
       self.ircd.write(ircUser.socket, 'irslackd', '341', [
         ircUser.ircNick,
         userId,

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -382,9 +382,13 @@ class Irslackd {
         nicksInChan.forEach((value, key) => {
           try {
             var slackId = ircUser.ircToSlack.get(key);
-            if (typeof slackId === 'undefined') throw Error('Cloud not find slackId,' + key + ', in ircToSlack');
+            if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
+            // cache may not have been filled yet ...
+            ircUser.mapSlackUser(key, slackId);
             var slackInfo = ircUser.slackUsersInfo.get(slackId);
-            if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId,' + slackId + ', in slackUsersInfo');
+            if (typeof slackInfo === 'undefined') {
+              throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');
+            }
             self.ircd.write(ircUser.socket, 'irslackd', '352', [
               ircUser.ircNick,
               chanSearch, // channel

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -379,12 +379,12 @@ class Irslackd {
         if (typeof nicksInChan === 'undefined') {
           throw new Error('Unknown channel ' + chanSearch);
         }
-        nicksInChan.forEach((value, key) => {
+        nicksInChan.forEach(async(value, key) => {
           try {
             var slackId = ircUser.ircToSlack.get(key);
             if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
             // cache may not have been filled yet ...
-            ircUser.mapSlackUser(key, slackId);
+            await ircUser.mapSlackUser(key, slackId);
             var slackInfo = ircUser.slackUsersInfo.get(slackId);
             if (typeof slackInfo === 'undefined') {
               throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -381,7 +381,9 @@ class Irslackd {
         }
         nicksInChan.forEach((value, key) => {
           var slackId = ircUser.ircToSlack.get(key);
+          if (typeof slackId === 'undefined') throw Error('Cloud not find slackId in ircToSlack');
           var slackInfo = ircUser.slackUsersInfo.get(slackId);
+          if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId in slackUsersInfo');
           self.ircd.write(ircUser.socket, 'irslackd', '352', [
             ircUser.ircNick,
             chanSearch, // channel
@@ -400,6 +402,7 @@ class Irslackd {
           // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
           var writeit = false;
           if (userSearch) {
+            if (typeof slackInfo.user === 'undefined') throw Error('slackInfo user was not populated');
             if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
               writeit = true;
             }

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -324,8 +324,10 @@ class Irslackd {
       if (msg.args.length !== 2) {
         throw Error('Must pass two params, the user to invite and the channel');
       }
-      var userId = ircUser.ircToSlack.get(msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]);
-      var channelId = ircUser.ircToSlack.get(msg.args[1]);
+      var ircChannel = msg.args[1];
+      var ircUserToInvite = msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0];
+      var userId = ircUser.ircToSlack.get(ircUserToInvite);
+      var channelId = ircUser.ircToSlack.get(ircChannel);
       if (!userId) throw Error('IRC nick not found in irslackd cache');
       if (!channelId) throw Error('IRC channel not found in irslackd cache');
       await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
@@ -334,8 +336,8 @@ class Irslackd {
       });
       self.ircd.write(ircUser.socket, 'irslackd', '341', [
         ircUser.ircNick,
-        userId,
-        channelId,
+        ircUserToInvite,
+        ircChannel,
       ]);
     } catch (e) {
       var message;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -32,7 +32,6 @@ class Irslackd {
       [ 'PING',       self.makeIrcHandler(self.onIrcPing)     ],
       [ 'MODE',       self.makeIrcHandler(self.onIrcMode)     ],
       [ 'LIST',       self.makeIrcHandler(self.onIrcList)     ],
-      [ 'LUSERS',     self.makeIrcHandler(self.onIrcListUsers)],
       [ 'ircLine',    self.makeIrcHandler(self.onIrcLine)     ],
       [ 'ircError',   self.makeIrcHandler(self.onIrcError)    ],
       [ 'ircClose',   self.makeIrcHandler(self.onIrcClose)    ],
@@ -308,14 +307,14 @@ class Irslackd {
       this.ircd.write(ircUser.socket, 'irslackd', 'MODE', msg.args);
     }
   }
-  async onIrcListUsers(ircUser, msg) {
+  async onIrcWho(ircUser, msg) {
     const self = this;
     var userSearch;
-    if (msg.args.length > 1) return; // Only support `LUSERS` with one params
+    if (msg.args.length > 1) return; // Only support `WHO` with one params
     if (msg.args.length > 0) {
       userSearch = msg.args[0];
     }
-    self.ircd.write(ircUser.socket, 'irslackd', '323', [ ircUser.ircNick, ':Start of LUSERS' ]);
+    self.ircd.write(ircUser.socket, 'irslackd', '371', [ ircUser.ircNick, ':Start of WHO' ]);
     let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
       presence: false,
       limit: 1000,
@@ -330,15 +329,20 @@ class Irslackd {
         writeit = true;
       }
       if (writeit) {
-        self.ircd.write(ircUser.socket, 'irslackd', '323', [
+        self.ircd.write(ircUser.socket, 'irslackd', '352', [
           ircUser.ircNick,
-          '@' + user.name,
+          '#',
           user.id,
+          "slack.com",
+          "example.com",
+          user.name,
+          user.profile.email?user.profile.email:"nobody@example.com",
+          "0",
           user.profile.real_name,
         ]);
       }
     });
-    self.ircd.write(ircUser.socket, 'irslackd', '323', [ ircUser.ircNick, ':End of LUSERS' ]);
+    self.ircd.write(ircUser.socket, 'irslackd', '315', [ ircUser.ircNick, ':End of WHO' ]);
   }
   async onIrcList(ircUser, msg) {
     const self = this;
@@ -633,9 +637,9 @@ class Irslackd {
     // Update presence subscriptions
     this.updatePresenceSubscriptions(ircUser);
   }
-  async onIrcWho(ircUser, msg) {
+/**  async onIrcWho(ircUser, msg) {
     await this.onIrcWhois(ircUser, msg);
-  }
+  }*/
   async onIrcWhois(ircUser, msg) {
     if (msg.args.length < 1) return;
     let ircNick = msg.args[0];

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -375,7 +375,7 @@ class Irslackd {
         userSearch = msg.args[0];
       }
       ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
-        console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
+        // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
         var writeit = false;
         if (userSearch) {
           if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -331,9 +331,9 @@ class Irslackd {
       if (writeit) {
         self.ircd.write(ircUser.socket, 'irslackd', '352', [
           ircUser.ircNick,
-          '#',
+          "#",
           user.id,
-          "slack.com",
+          "irslackd",
           "example.com",
           user.name,
           user.profile.email?user.profile.email:"nobody@example.com",

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -379,7 +379,7 @@ class Irslackd {
         if (typeof nicksInChan === 'undefined') {
           throw new Error('Unknown channel ' + chanSearch);
         }
-        var itemsProcessed = 0;
+        var itemsProcessed = nicksInChan.length;
         nicksInChan.forEach(async(value, key) => {
           var slackId = ircUser.ircToSlack.get(key);
           if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
@@ -400,8 +400,8 @@ class Irslackd {
             ':0 ' +
             (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
           ]);
-          itemsProcessed++;
-          if (itemsProcessed === nicksInChan.length) () => {
+          itemsProcessed -= 1;
+          if (itemsProcessed === 0) () => {
             self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
           };
         });

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -364,27 +364,25 @@ class Irslackd {
   async onIrcWho(ircUser, msg) {
     const self = this;
     try {
-      var userSearch;
+      var userSearch, chanSearch;
       if (msg.args.length > 1) {
         throw Error('/WHO only supports one parameter');
       }
       if (msg.args.length > 0 && msg.args[0].substr(0, 1) === '#') {
-        throw Error('channels not implemented');
+        chanSearch = msg.args[0];
       }
       if (msg.args.length > 0) {
         userSearch = msg.args[0];
       }
-      ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
-        // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
-        var writeit = false;
-        if (userSearch) {
-          if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
-            writeit = true;
-          }
-        } else {
-          writeit = true;
-        }
-        if (writeit) {
+      if (chanSearch) {
+        var nicksInChan = ircUser.channelNicks.get(chanSearch);
+        console.debug(nicksInChan);
+        nicksInChan.forEach((value, key) => {
+          console.debug('key / value: ' + key + '/' + value);
+          var slackId = ircUser.ircToSlack.get(key);
+          console.debug('slackid: ' + slackId);
+          var slackInfo = ircUser.slackUsersInfo.get(slackId);
+          console.debug('slackinfo: ' + slackInfo);
           self.ircd.write(ircUser.socket, 'irslackd', '352', [
             ircUser.ircNick,
             '*',
@@ -396,8 +394,34 @@ class Irslackd {
             '0',
             slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody',
           ]);
-        }
-      });
+
+        });
+      } else {
+        ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
+        // console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
+          var writeit = false;
+          if (userSearch) {
+            if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
+              writeit = true;
+            }
+          } else {
+            writeit = true;
+          }
+          if (writeit) {
+            self.ircd.write(ircUser.socket, 'irslackd', '352', [
+              ircUser.ircNick,
+              '*',
+              slackInfo.user.id,
+              'irslackd',
+              'example.com',
+              slackInfo.user.name,
+              slackInfo.user.profile.email ? slackInfo.user.profile.email : 'nobody@example.com',
+              '0',
+              slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody',
+            ]);
+          }
+        });
+      }
       self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO']);
     } catch (e) {
       var message;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -326,6 +326,8 @@ class Irslackd {
       }
       var userId = ircUser.ircToSlack.get(msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]);
       var channelId = ircUser.ircToSlack.get(msg.args[1]);
+      if (!userId) throw Error('IRC nick not found in irslackd cache');
+      if (!channelId) throw Error('IRC channel not found in irslackd cache');
       await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
         users: userId,
         channel: channelId,

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -380,22 +380,37 @@ class Irslackd {
           throw new Error('Unknown channel ' + chanSearch);
         }
         nicksInChan.forEach((value, key) => {
-          var slackId = ircUser.ircToSlack.get(key);
-          if (typeof slackId === 'undefined') throw Error('Cloud not find slackId in ircToSlack');
-          var slackInfo = ircUser.slackUsersInfo.get(slackId);
-          if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId in slackUsersInfo');
-          self.ircd.write(ircUser.socket, 'irslackd', '352', [
-            ircUser.ircNick,
-            chanSearch, // channel
-            slackInfo.user.id, // user
-            'irslackd', // host
-            'example.com', // server
-            slackInfo.user.name, // nick
-            'H',
-            ':0 ' +
+          try {
+            var slackId = ircUser.ircToSlack.get(key);
+            if (typeof slackId === 'undefined') throw Error('Cloud not find slackId in ircToSlack');
+            var slackInfo = ircUser.slackUsersInfo.get(slackId);
+            if (typeof slackInfo === 'undefined') throw Error('Cloud not find slackId in slackUsersInfo');
+            self.ircd.write(ircUser.socket, 'irslackd', '352', [
+              ircUser.ircNick,
+              chanSearch, // channel
+              slackInfo.user.id, // user
+              'irslackd', // host
+              'example.com', // server
+              slackInfo.user.name, // nick
+              'H',
+              ':0 ' +
             (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
-          ]);
-
+            ]);
+          } catch (e) {
+            var message;
+            if (this.isJson(e.message)) {
+              var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
+              message = ':/WHO failed->' +
+              JSON.parse(e.message).error.code + '->' +
+              errorFromData;
+            } else {
+              message = ':/WHO failed->' + e.message;
+            }
+            self.ircd.write(ircUser.socket, 'irslackd', '371', [
+              ircUser.ircNick,
+              message,
+            ]);
+          }
         });
       } else {
         ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -27,6 +27,7 @@ class Irslackd {
       [ 'PRIVMSG',    self.makeIrcHandler(self.onIrcPrivmsg)  ],
       [ 'QUIT',       self.makeIrcHandler(self.onIrcQuit)     ],
       [ 'USER',       self.makeIrcHandler(self.onIrcUser)     ],
+      [ 'INVITE',     self.makeIrcHandler(self.onIrcInvite)   ],
       [ 'WHO',        self.makeIrcHandler(self.onIrcWho)      ],
       [ 'WHOIS',      self.makeIrcHandler(self.onIrcWhois)    ],
       [ 'PING',       self.makeIrcHandler(self.onIrcPing)     ],
@@ -307,10 +308,78 @@ class Irslackd {
       this.ircd.write(ircUser.socket, 'irslackd', 'MODE', msg.args);
     }
   }
+  /**
+   * @todo: work in progress
+   * @param {*} ircUser 
+   * @param {*} msg 
+   */
+  async onIrcInvite(ircUser, msg) {
+    console.log("in the irc invite method");
+    const self = this;
+    if (msg.args.length !== 2) {
+      self.ircd.write(ircUser.socket, 'irslackd', '371', [ ircUser.ircNick, ':Must pass two params, the user to invite and the channel' ]);
+      return; // must have two params (nick and channel)
+    }
+    var userId = await self.lookupUserId(ircUser, msg.args[0]);
+    var channelId = await self.lookupChannelId(ircUser, msg.args[1].substr(1)); // remove hash
+    await ircUser.slackWeb.paginateCallOrThrow('channels.invite', 'channel', {
+      channel: channelId,
+      user: userId,
+    });
+    self.ircd.write(ircUser.socket, 'irslackd', '341', [
+      ircUser.ircNick,
+      channelId,
+      userId, 
+    ]);
+  }
+  async lookupChannelId(ircUser, channelName) {
+    var channelId;
+    let conversations = await ircUser.slackWeb.paginateCallOrThrow('conversations.list', 'channels', {
+      types: "public_channel, private_channel, mpim, im",
+      exclude_archived: true,
+      limit: 1000,
+    });
+    var BreakException = {};
+    try {
+      conversations.channels.forEach((channel) => {
+        if (channel.name === channelName) {
+          channelId = channel.id;
+          throw BreakException;
+        }
+      });
+    } catch (e) {
+      if (e !== BreakException) throw e;
+    }
+    return channelId;
+  }
+  async lookupUserId(ircUser, userName) {
+    var userId;
+    let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
+      presence: false,
+      limit: 1000,
+    });
+    var BreakException = {};
+    try {
+      users.members.forEach((member) => {
+        if (member.name === userName) {
+          userId = member.id;
+          throw BreakException;
+        }
+      });
+    } catch (e) {
+      if (e !== BreakException) throw e;
+    }
+    return userId;
+  }
   async onIrcWho(ircUser, msg) {
     const self = this;
-    var userSearch;
+    var userSearch, channelSearch;
     if (msg.args.length > 1) return; // Only support `WHO` with one params
+    if (msg.args.length > 0 && msg.args[0].substr(0,1) === "#") {
+      channelSearch = msg.args[0].substr(1);
+      self.ircd.write(ircUser.socket, 'irslackd', '315', [ ircUser.ircNick, ':End of WHO - channels not implemented' ]);
+      return;
+    }
     if (msg.args.length > 0) {
       userSearch = msg.args[0];
     }
@@ -331,7 +400,7 @@ class Irslackd {
       if (writeit) {
         self.ircd.write(ircUser.socket, 'irslackd', '352', [
           ircUser.ircNick,
-          "#",
+          "*",
           user.id,
           "irslackd",
           "example.com",

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -352,45 +352,6 @@ class Irslackd {
       ]);
     }
   }
-  // async lookupChannelId(ircUser, channelName) {
-  //   var channelId;
-  //   let conversations = await ircUser.slackWeb.paginateCallOrThrow('conversations.list', 'channels', {
-  //     types: 'public_channel, private_channel, mpim, im',
-  //     exclude_archived: true,
-  //     limit: 1000,
-  //   });
-  //   var BreakException = {};
-  //   try {
-  //     conversations.channels.forEach((channel) => {
-  //       if (channel.name === channelName) {
-  //         channelId = channel.id;
-  //         throw BreakException;
-  //       }
-  //     });
-  //   } catch (e) {
-  //     if (e !== BreakException) throw e;
-  //   }
-  //   return channelId;
-  // }
-  // async lookupUserId(ircUser, userName) {
-  //   var userId;
-  //   let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
-  //     presence: false,
-  //     limit: 1000,
-  //   });
-  //   var BreakException = {};
-  //   try {
-  //     users.members.forEach((member) => {
-  //       if (member.name === userName) {
-  //         userId = member.id;
-  //         throw BreakException;
-  //       }
-  //     });
-  //   } catch (e) {
-  //     if (e !== BreakException) throw e;
-  //   }
-  //   return userId;
-  // }
   async onIrcWho(ircUser, msg) {
     const self = this;
     var userSearch;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -397,7 +397,7 @@ class Irslackd {
             slackInfo.user.id, // user
             'irslackd', // host
             'example.com', // server
-            slackInfo.user.name, // nick
+            ircNickId, // nick
             ircUser.ircNickActive.has(ircNickId) ? 'H' : 'G',
             ':0 ' +
             (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -314,7 +314,6 @@ class Irslackd {
    * @param {*} msg 
    */
   async onIrcInvite(ircUser, msg) {
-    console.log("in the irc invite method");
     const self = this;
     if (msg.args.length !== 2) {
       self.ircd.write(ircUser.socket, 'irslackd', '371', [ ircUser.ircNick, ':Must pass two params, the user to invite and the channel' ]);
@@ -335,7 +334,7 @@ class Irslackd {
   async lookupChannelId(ircUser, channelName) {
     var channelId;
     let conversations = await ircUser.slackWeb.paginateCallOrThrow('conversations.list', 'channels', {
-      types: "public_channel, private_channel, mpim, im",
+      types: 'public_channel, private_channel, mpim, im',
       exclude_archived: true,
       limit: 1000,
     });
@@ -375,7 +374,7 @@ class Irslackd {
     const self = this;
     var userSearch, channelSearch;
     if (msg.args.length > 1) return; // Only support `WHO` with one params
-    if (msg.args.length > 0 && msg.args[0].substr(0,1) === "#") {
+    if (msg.args.length > 0 && msg.args[0].substr(0,1) === '#') {
       channelSearch = msg.args[0].substr(1);
       self.ircd.write(ircUser.socket, 'irslackd', '315', [ ircUser.ircNick, ':End of WHO - channels not implemented' ]);
       return;
@@ -400,13 +399,13 @@ class Irslackd {
       if (writeit) {
         self.ircd.write(ircUser.socket, 'irslackd', '352', [
           ircUser.ircNick,
-          "*",
+          '*',
           user.id,
-          "irslackd",
-          "example.com",
+          'irslackd',
+          'example.com',
           user.name,
-          user.profile.email?user.profile.email:"nobody@example.com",
-          "0",
+          user.profile.email?user.profile.email:'nobody@example.com',
+          '0',
           user.profile.real_name,
         ]);
       }

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -427,7 +427,7 @@ class Irslackd {
               slackInfo.user.id, // user
               'irslackd', // host
               'example.com', // server
-              slackInfo.user.name, // nick
+              ircNickId, // nick
               ircUser.ircNickActive.has(ircNickId) ? 'H' : 'G',
               ':0 ' +
               (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -334,8 +334,8 @@ class Irslackd {
       console.debug('invite call response: ' + JSON.stringify(result));
       self.ircd.write(ircUser.socket, 'irslackd', '341', [
         ircUser.ircNick,
-        channelId,
         userId,
+        channelId,
       ]);
     } catch (e) {
       console.debug('invite call failed response: ' + JSON.stringify(e.message));

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -320,7 +320,6 @@ class Irslackd {
   }
   async onIrcInvite(ircUser, msg) {
     const self = this;
-
     try {
       if (msg.args.length !== 2) {
         self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Must pass two params, the user to invite and the channel']);
@@ -328,16 +327,18 @@ class Irslackd {
       }
       var userId = await self.lookupUserId(ircUser, msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]); // remove at-sign
       var channelId = await self.lookupChannelId(ircUser, msg.args[1].substr(0, 1) === '#' ? msg.args[1].substr(1) : msg.args[1]); // remove hash
-      await ircUser.slackWeb.paginateCallOrThrow('channels.invite', 'channel', {
+      var result = await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
+        users: userId,
         channel: channelId,
-        user: userId,
       });
+      console.debug('invite call response: ' + JSON.stringify(result));
       self.ircd.write(ircUser.socket, 'irslackd', '341', [
         ircUser.ircNick,
         channelId,
         userId,
       ]);
     } catch (e) {
+      console.debug('invite call failed response: ' + JSON.stringify(e.message));
       self.ircd.write(ircUser.socket, 'irslackd', '371', [
         ircUser.ircNick, ':/INVITE failed->' +
         JSON.parse(e.message).error.code + '->' +
@@ -1125,7 +1126,9 @@ class Irslackd {
     return new ircd.Ircd(tlsOpts);
   }
   getNewSlackWebClient(token) {
-    return new slack.WebClient(token);
+    return new slack.WebClient(token, {
+      logLevel: this.config.rtmClientLogLevel || 'info',
+    });
   }
   getNewSlackRtmClient(token) {
     return new slack.RTMClient(token, {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -322,8 +322,7 @@ class Irslackd {
     const self = this;
     try {
       if (msg.args.length !== 2) {
-        self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Must pass two params, the user to invite and the channel']);
-        return; // must have two params (nick and channel)
+        throw Error('Must pass two params, the user to invite and the channel');
       }
       // var userId = await self.lookupUserId(ircUser, msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]); // remove at-sign
       var channelId = await self.lookupChannelId(ircUser, msg.args[1].substr(0, 1) === '#' ? msg.args[1].substr(1) : msg.args[1]); // remove hash
@@ -340,11 +339,18 @@ class Irslackd {
         channelId,
       ]);
     } catch (e) {
-      var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
-      self.ircd.write(ircUser.socket, 'irslackd', '371', [
-        ircUser.ircNick, ':/INVITE failed->' +
+      var message;
+      if (JSON.parse(e.message).error.code) {
+        var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
+        message = ':/INVITE failed->' +
         JSON.parse(e.message).error.code + '->' +
-        errorFromData,
+        errorFromData;
+      } else {
+        message = ':/INVITE failed->' + e.message;
+      }
+      self.ircd.write(ircUser.socket, 'irslackd', '371', [
+        ircUser.ircNick,
+        message,
       ]);
     }
   }

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -323,7 +323,7 @@ class Irslackd {
     users.members.forEach((user) => {
       var writeit = false;
       if (userSearch) {
-        if (user.name.toLowerCase().toLowerCase().indexOf(userSearch.toLowerCase()) > 0) {
+        if (user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
           writeit = true;
         }
       } else {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -363,44 +363,57 @@ class Irslackd {
   }
   async onIrcWho(ircUser, msg) {
     const self = this;
-    var userSearch;
-    if (msg.args.length > 1) return; // Only support `WHO` with one params
-    if (msg.args.length > 0 && msg.args[0].substr(0, 1) === '#') {
-      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO - channels not implemented']);
-      return;
-    }
-    if (msg.args.length > 0) {
-      userSearch = msg.args[0];
-    }
-    // self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Start of WHO']);
-    let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
-      presence: false,
-      limit: 1000,
-    });
-    users.members.forEach((user) => {
-      var writeit = false;
-      if (userSearch) {
-        if (user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
+    try {
+      var userSearch;
+      if (msg.args.length > 1) {
+        throw Error('/WHO only supports one parameter');
+      }
+      if (msg.args.length > 0 && msg.args[0].substr(0, 1) === '#') {
+        throw Error('channels not implemented');
+      }
+      if (msg.args.length > 0) {
+        userSearch = msg.args[0];
+      }
+      ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
+        console.debug('slackinfo --> ' + JSON.stringify(slackInfo));
+        var writeit = false;
+        if (userSearch) {
+          if (slackInfo.user.name.toLowerCase().indexOf(userSearch.toLowerCase()) > -1) {
+            writeit = true;
+          }
+        } else {
           writeit = true;
         }
+        if (writeit) {
+          self.ircd.write(ircUser.socket, 'irslackd', '352', [
+            ircUser.ircNick,
+            '*',
+            slackInfo.user.id,
+            'irslackd',
+            'example.com',
+            slackInfo.user.name,
+            slackInfo.user.profile.email ? slackInfo.user.profile.email : 'nobody@example.com',
+            '0',
+            slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody',
+          ]);
+        }
+      });
+      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO']);
+    } catch (e) {
+      var message;
+      if (this.isJson(e.message)) {
+        var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
+        message = ':/WHO failed->' +
+        JSON.parse(e.message).error.code + '->' +
+        errorFromData;
       } else {
-        writeit = true;
+        message = ':/WHO failed->' + e.message;
       }
-      if (writeit) {
-        self.ircd.write(ircUser.socket, 'irslackd', '352', [
-          ircUser.ircNick,
-          '*',
-          user.id,
-          'irslackd',
-          'example.com',
-          user.name,
-          user.profile.email ? user.profile.email : 'nobody@example.com',
-          '0',
-          user.profile.real_name ? user.profile.real_name : 'Nobody',
-        ]);
-      }
-    });
-    self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, ':End of WHO']);
+      self.ircd.write(ircUser.socket, 'irslackd', '371', [
+        ircUser.ircNick,
+        message,
+      ]);
+    }
   }
   async onIrcList(ircUser, msg) {
     const self = this;
@@ -1122,6 +1135,7 @@ class IrcUser {
     this.slackUserId = 'uid';
     this.slackWeb = null;
     this.slackRtm = null;
+    this.slackUsersInfo = new Map();
     this.channelNicks = new Map();
     this.ircToSlack = new Map();
     this.slackToIrc = new Map();
@@ -1197,6 +1211,14 @@ class IrcUser {
     }
     this.ircToSlack.set(ircTarget, slackId);
     this.slackToIrc.set(slackId, ircTarget);
+    this.mapSlackUser(ircTarget, slackId);
+  }
+  async mapSlackUser(ircTarget, slackId) {
+    if (ircTarget.substr(0, 1) === '#') return;
+    var user = await this.slackWeb.paginateCallOrThrow('users.info', 'user', {
+      user: slackId,
+    });
+    this.slackUsersInfo.set(slackId, user);
   }
 }
 

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -339,7 +339,7 @@ class Irslackd {
       ]);
     } catch (e) {
       var message;
-      if (JSON.parse(e.message).error.code) {
+      if (this.isJson(e.message)) {
         var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
         message = ':/INVITE failed->' +
         JSON.parse(e.message).error.code + '->' +
@@ -352,6 +352,14 @@ class Irslackd {
         message,
       ]);
     }
+  }
+  isJson(str) {
+    try {
+      JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
+    return true;
   }
   async onIrcWho(ircUser, msg) {
     const self = this;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -325,8 +325,10 @@ class Irslackd {
         self.ircd.write(ircUser.socket, 'irslackd', '371', [ircUser.ircNick, ':Must pass two params, the user to invite and the channel']);
         return; // must have two params (nick and channel)
       }
-      var userId = await self.lookupUserId(ircUser, msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]); // remove at-sign
+      // var userId = await self.lookupUserId(ircUser, msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]); // remove at-sign
       var channelId = await self.lookupChannelId(ircUser, msg.args[1].substr(0, 1) === '#' ? msg.args[1].substr(1) : msg.args[1]); // remove hash
+      var userId = ircUser.ircToSlack.get(msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]);
+      // var channelId = ircUser.
       var result = await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
         users: userId,
         channel: channelId,
@@ -366,25 +368,25 @@ class Irslackd {
     }
     return channelId;
   }
-  async lookupUserId(ircUser, userName) {
-    var userId;
-    let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
-      presence: false,
-      limit: 1000,
-    });
-    var BreakException = {};
-    try {
-      users.members.forEach((member) => {
-        if (member.name === userName) {
-          userId = member.id;
-          throw BreakException;
-        }
-      });
-    } catch (e) {
-      if (e !== BreakException) throw e;
-    }
-    return userId;
-  }
+  // async lookupUserId(ircUser, userName) {
+  //   var userId;
+  //   let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {
+  //     presence: false,
+  //     limit: 1000,
+  //   });
+  //   var BreakException = {};
+  //   try {
+  //     users.members.forEach((member) => {
+  //       if (member.name === userName) {
+  //         userId = member.id;
+  //         throw BreakException;
+  //       }
+  //     });
+  //   } catch (e) {
+  //     if (e !== BreakException) throw e;
+  //   }
+  //   return userId;
+  // }
   async onIrcWho(ircUser, msg) {
     const self = this;
     var userSearch;

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -324,10 +324,8 @@ class Irslackd {
       if (msg.args.length !== 2) {
         throw Error('Must pass two params, the user to invite and the channel');
       }
-      // var userId = await self.lookupUserId(ircUser, msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]); // remove at-sign
-      var channelId = await self.lookupChannelId(ircUser, msg.args[1].substr(0, 1) === '#' ? msg.args[1].substr(1) : msg.args[1]); // remove hash
       var userId = ircUser.ircToSlack.get(msg.args[0].substr(0, 1) === '@' ? msg.args[0].substr(1) : msg.args[0]);
-      // var channelId = ircUser.
+      var channelId = ircUser.ircToSlack.get(msg.args[1]);
       var result = await ircUser.slackWeb.paginateCallOrThrow('conversations.invite', 'channel', {
         users: userId,
         channel: channelId,
@@ -354,26 +352,26 @@ class Irslackd {
       ]);
     }
   }
-  async lookupChannelId(ircUser, channelName) {
-    var channelId;
-    let conversations = await ircUser.slackWeb.paginateCallOrThrow('conversations.list', 'channels', {
-      types: 'public_channel, private_channel, mpim, im',
-      exclude_archived: true,
-      limit: 1000,
-    });
-    var BreakException = {};
-    try {
-      conversations.channels.forEach((channel) => {
-        if (channel.name === channelName) {
-          channelId = channel.id;
-          throw BreakException;
-        }
-      });
-    } catch (e) {
-      if (e !== BreakException) throw e;
-    }
-    return channelId;
-  }
+  // async lookupChannelId(ircUser, channelName) {
+  //   var channelId;
+  //   let conversations = await ircUser.slackWeb.paginateCallOrThrow('conversations.list', 'channels', {
+  //     types: 'public_channel, private_channel, mpim, im',
+  //     exclude_archived: true,
+  //     limit: 1000,
+  //   });
+  //   var BreakException = {};
+  //   try {
+  //     conversations.channels.forEach((channel) => {
+  //       if (channel.name === channelName) {
+  //         channelId = channel.id;
+  //         throw BreakException;
+  //       }
+  //     });
+  //   } catch (e) {
+  //     if (e !== BreakException) throw e;
+  //   }
+  //   return channelId;
+  // }
   // async lookupUserId(ircUser, userName) {
   //   var userId;
   //   let users = await ircUser.slackWeb.paginateCallOrThrow('users.list', 'members', {

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -379,42 +379,31 @@ class Irslackd {
         if (typeof nicksInChan === 'undefined') {
           throw new Error('Unknown channel ' + chanSearch);
         }
+        var itemsProcessed = 0;
         nicksInChan.forEach(async(value, key) => {
-          try {
-            var slackId = ircUser.ircToSlack.get(key);
-            if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
-            // cache may not have been filled yet ...
-            await ircUser.mapSlackUser(key, slackId);
-            var slackInfo = ircUser.slackUsersInfo.get(slackId);
-            if (typeof slackInfo === 'undefined') {
-              throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');
-            }
-            self.ircd.write(ircUser.socket, 'irslackd', '352', [
-              ircUser.ircNick,
-              chanSearch, // channel
-              slackInfo.user.id, // user
-              'irslackd', // host
-              'example.com', // server
-              slackInfo.user.name, // nick
-              'H',
-              ':0 ' +
-            (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
-            ]);
-          } catch (e) {
-            var message;
-            if (this.isJson(e.message)) {
-              var errorFromData = typeof JSON.parse(e.message).error.data !== 'undefined' ? JSON.parse(e.message).error.data.error : 'no data element in error response';
-              message = ':/WHO failed->' +
-              JSON.parse(e.message).error.code + '->' +
-              errorFromData;
-            } else {
-              message = ':/WHO failed->' + e.message;
-            }
-            self.ircd.write(ircUser.socket, 'irslackd', '371', [
-              ircUser.ircNick,
-              message,
-            ]);
+          var slackId = ircUser.ircToSlack.get(key);
+          if (typeof slackId === 'undefined') throw Error('Could not find slackId,' + key + ', in ircToSlack');
+          // cache may not have been filled yet ...
+          await ircUser.mapSlackUser(key, slackId);
+          var slackInfo = ircUser.slackUsersInfo.get(slackId);
+          if (typeof slackInfo === 'undefined') {
+            throw Error('Could not find slackId,' + slackId + ', in slackUsersInfo');
           }
+          self.ircd.write(ircUser.socket, 'irslackd', '352', [
+            ircUser.ircNick,
+            chanSearch, // channel
+            slackInfo.user.id, // user
+            'irslackd', // host
+            'example.com', // server
+            slackInfo.user.name, // nick
+            'H',
+            ':0 ' +
+            (slackInfo.user.profile.real_name ? slackInfo.user.profile.real_name : 'Nobody') + (slackInfo.user.profile.email ? '<' + slackInfo.user.profile.email + '>' : ''), // real name,
+          ]);
+          itemsProcessed++;
+          if (itemsProcessed === nicksInChan.length) () => {
+            self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
+          };
         });
       } else {
         ircUser.slackUsersInfo.forEach((slackInfo, slackId, theMap) => {
@@ -442,8 +431,8 @@ class Irslackd {
             ]);
           }
         });
+        self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
       }
-      self.ircd.write(ircUser.socket, 'irslackd', '315', [ircUser.ircNick, userSearch || '#', ':End of WHO list']);
     } catch (e) {
       var message;
       if (this.isJson(e.message)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,9 +1460,9 @@
       }
     },
     "tape": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.1.tgz",
-      "integrity": "sha512-6fKIXknLpoe/Jp4rzHKFPpJUHDHDqn8jus99IfPnHIjyz78HYlefTGD3b5EkbQzuLfaEvmfPK3IolLgq2xT3kw==",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.2.tgz",
+      "integrity": "sha512-lPXKRKILZ1kZaUy5ynWKs8ATGSUO7HAFHCFnBam6FaGSqPdOwMWbxXHq4EXFLE8WRTleo/YOMXkaUTRmTB1Fiw==",
       "requires": {
         "deep-equal": "~1.0.1",
         "defined": "~1.0.0",
@@ -1481,7 +1481,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@slack/client": "^4.8.0",
     "await-lock": "^1.1.3",
     "node-getopt": "^0.3.2",
-    "tape": "^4.9.1"
+    "tape": "^4.9.2"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/adsr/irslackd#readme",
   "scripts": {
     "pretest": "eslint --ignore-path .gitignore .",
-    "test": "testfn() { patt=${@:-test_}; find tests -name \"*${patt}*\" | xargs -rn1 node | awk -f bin/filter-tape.awk; }; testfn"
+    "test": "testfn() { patt=${@:-test_}; find tests -name \"*${patt}*\" | xargs -n1 node | awk -f bin/filter-tape.awk; }; testfn"
   },
   "dependencies": {
     "@slack/client": "^4.8.0",

--- a/tests/test_connect.js
+++ b/tests/test_connect.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('connect_simple', async(t) => {
-  t.plan(mocks.connectOneIrcClient.planCout);
+  t.plan(mocks.connectOneIrcClient.planCount);
   await mocks.connectOneIrcClient(t);
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -8,10 +8,6 @@ test('irc_invite', async(t) => {
   const c = await mocks.connectOneIrcClient(t);
   c.ircUser.mapIrcToSlack('fun_user', 'U1234USER');
   c.ircUser.mapIrcToSlack('#fun_channel', 'C1234CHAN1');
-  console.log('irctoslack:');
-  for (var i = 0, keys = Object.keys(c.ircUser.ircToSlack), ii = keys.length; i < ii; i++) {
-    console.log(keys[i] + '|' + c.ircUser.ircToSlack[keys[i]].list);
-  }
   c.slackWeb.expect('conversations.invite', { users: 'U1234USER',
     channel: 'C1234CHAN1'}, {
     ok: true,
@@ -28,11 +24,7 @@ test('irc_invite_not_in_cache', async(t) => {
   t.plan(1 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   // c.ircUser.mapIrcToSlack('fun_user', 'U1234USER');
-  c.ircUser.mapIrcToSlack('#fun_channel', 'C1234CHAN1');
-  console.log('irctoslack:');
-  for (var i = 0, keys = Object.keys(c.ircUser.ircToSlack), ii = keys.length; i < ii; i++) {
-    console.log(keys[i] + '|' + c.ircUser.ircToSlack[keys[i]].list);
-  }
+  // c.ircUser.mapIrcToSlack('#fun_channel', 'C1234CHAN1');
   c.ircSocket.expect(':irslackd 371 test_slack_user :/INVITE failed->IRC nick not found in irslackd cache');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
   t.end();

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -3,7 +3,7 @@
 const test = require('tape');
 const mocks = require('./mocks');
 
-test('irc_list', async(t) => {
+test('irc_invite', async(t) => {
   t.plan(5 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('channel.invite', { exclude_archived: true, types: 'public_channel', limit: 1000 }, {

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('irc_invite', async(t) => {
-  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  t.plan(2 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('conversations.invite', { users: 'U1235BARR',
     channel: 'CFOOBAR'}, {

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -23,3 +23,17 @@ test('irc_invite', async(t) => {
   await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
   t.end();
 });
+
+test('irc_invite_not_in_cache', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  // c.ircUser.mapIrcToSlack('fun_user', 'U1234USER');
+  c.ircUser.mapIrcToSlack('#fun_channel', 'C1234CHAN1');
+  console.log('irctoslack:');
+  for (var i = 0, keys = Object.keys(c.ircUser.ircToSlack), ii = keys.length; i < ii; i++) {
+    console.log(keys[i] + '|' + c.ircUser.ircToSlack[keys[i]].list);
+  }
+  c.ircSocket.expect(':irslackd 371 test_slack_user :/INVITE failed->IRC nick not found in irslackd cache');
+  await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
+  t.end();
+});

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -19,7 +19,7 @@ test('irc_invite', async(t) => {
       { id: 'C1234CHAN1' },
     ],
   });
-  c.ircSocket.expect(':irslackd 341 jay has invited U1234USER to C1234CHAN1');
+  c.ircSocket.expect(':irslackd 341 test_slack_user U1234USER C1234CHAN1');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -13,7 +13,7 @@ test('irc_invite', async(t) => {
       { id: 'CFOOBAR' },
     ],
   });
-  c.ircSocket.expect('jay has invited U1235BARR to CFOOBAR');
+  c.ircSocket.expect(':irslackd 341 jay has invited U1235BARR to CFOOBAR');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['U1235BARR', 'CFOOBAR'] });
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -6,14 +6,20 @@ const mocks = require('./mocks');
 test('irc_invite', async(t) => {
   t.plan(2 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
-  c.slackWeb.expect('conversations.invite', { users: 'U1235BARR',
-    channel: 'CFOOBAR'}, {
+  c.ircUser.mapIrcToSlack('fun_user', 'U1234USER');
+  c.ircUser.mapIrcToSlack('#fun_channel', 'C1234CHAN1');
+  console.log('irctoslack:');
+  for (var i = 0, keys = Object.keys(c.ircUser.ircToSlack), ii = keys.length; i < ii; i++) {
+    console.log(keys[i] + '|' + c.ircUser.ircToSlack[keys[i]].list);
+  }
+  c.slackWeb.expect('conversations.invite', { users: 'U1234USER',
+    channel: 'C1234CHAN1'}, {
     ok: true,
     channel: [
-      { id: 'CFOOBAR' },
+      { id: 'C1234CHAN1' },
     ],
   });
-  c.ircSocket.expect(':irslackd 341 jay has invited U1235BARR to CFOOBAR');
-  await c.daemon.onIrcInvite(c.ircUser, { args: ['U1235BARR', 'CFOOBAR'] });
+  c.ircSocket.expect(':irslackd 341 jay has invited U1234USER to C1234CHAN1');
+  await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -4,20 +4,16 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('irc_invite', async(t) => {
-  t.plan(5 + mocks.connectOneIrcClient.planCount);
+  t.plan(mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
-  c.slackWeb.expect('channel.invite', { exclude_archived: true, types: 'public_channel', limit: 1000 }, {
+  c.slackWeb.expect('channel.invite', { users: 'U1234USER',
+    channel: 'CFOOBAR'}, {
     ok: true,
-    channels: [
-      { name: 'chan1', num_members: 1, topic: { value: 'chan1 topic' } },
-      { name: 'chan2', num_members: 2, topic: { value: 'chan2 topic' } },
-      { name: 'chan3', num_members: 3, topic: { value: 'chan3 topic' } },
+    channel: [
+      { id: 'CFOOBAR' },
     ],
   });
-  c.ircSocket.expect(':irslackd 322 test_slack_user #chan1 1 :chan1 topic');
-  c.ircSocket.expect(':irslackd 322 test_slack_user #chan2 2 :chan2 topic');
-  c.ircSocket.expect(':irslackd 322 test_slack_user #chan3 3 :chan3 topic');
-  c.ircSocket.expect(':irslackd 323 test_slack_user :End of LIST');
+  c.ircSocket.expect('jay has invited U1234USER to CFOOBAR');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['U1234USER', 'CFOOBAR'] });
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -15,7 +15,9 @@ test('irc_invite', async(t) => {
       { id: 'C1234CHAN1' },
     ],
   });
-  c.ircSocket.expect(':irslackd 341 test_slack_user U1234USER C1234CHAN1');
+  // RPL_INVITING
+  // <source> 341 <target> <nick> <channel>
+  c.ircSocket.expect(':irslackd 341 test_slack_user fun_user #fun_channel');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['fun_user', '#fun_channel'] });
   t.end();
 });

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const test = require('tape');
+const mocks = require('./mocks');
+
+test('irc_list', async(t) => {
+  t.plan(5 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.slackWeb.expect('channel.invite', { exclude_archived: true, types: 'public_channel', limit: 1000 }, {
+    ok: true,
+    channels: [
+      { name: 'chan1', num_members: 1, topic: { value: 'chan1 topic' } },
+      { name: 'chan2', num_members: 2, topic: { value: 'chan2 topic' } },
+      { name: 'chan3', num_members: 3, topic: { value: 'chan3 topic' } },
+    ],
+  });
+  c.ircSocket.expect(':irslackd 322 test_slack_user #chan1 1 :chan1 topic');
+  c.ircSocket.expect(':irslackd 322 test_slack_user #chan2 2 :chan2 topic');
+  c.ircSocket.expect(':irslackd 322 test_slack_user #chan3 3 :chan3 topic');
+  c.ircSocket.expect(':irslackd 323 test_slack_user :End of LIST');
+  await c.daemon.onIrcInvite(c.ircUser, { args: ['U1234USER', 'CFOOBAR'] });
+  t.end();
+});

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -4,16 +4,16 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('irc_invite', async(t) => {
-  t.plan(mocks.connectOneIrcClient.planCount);
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
-  c.slackWeb.expect('channel.invite', { users: 'U1234USER',
+  c.slackWeb.expect('conversations.invite', { users: 'U1235BARR',
     channel: 'CFOOBAR'}, {
     ok: true,
     channel: [
       { id: 'CFOOBAR' },
     ],
   });
-  c.ircSocket.expect('jay has invited U1234USER to CFOOBAR');
-  await c.daemon.onIrcInvite(c.ircUser, { args: ['U1234USER', 'CFOOBAR'] });
+  c.ircSocket.expect('jay has invited U1235BARR to CFOOBAR');
+  await c.daemon.onIrcInvite(c.ircUser, { args: ['U1235BARR', 'CFOOBAR'] });
   t.end();
 });

--- a/tests/test_who.js
+++ b/tests/test_who.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const test = require('tape');
+const mocks = require('./mocks');
+
+test('irc_who', async(t) => {
+  t.plan(3 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.ircUser.mapIrcToSlack('fun_user', 'U1234USER');
+  c.slackWeb.expect('users.list', {
+    presence: false,
+    limit: 1000}, {
+    ok: true,
+    members: [
+      { name: 'fun_user',
+        id: 'U1234USER',
+        profile: [
+          {email: 'foo@example.com',
+            real_name: 'Foo Bar' },
+        ]},
+    ],
+  });
+  c.ircSocket.expect(':irslackd 352 test_slack_user * U1234USER irslackd example.com fun_user nobody@example.com 0 Nobody');
+  c.ircSocket.expect(':irslackd 315 test_slack_user :End of WHO');
+  await c.daemon.onIrcWho(c.ircUser, { args: ['fun_user'] });
+  t.end();
+});


### PR DESCRIPTION
retooled the /who feature to use locally cached data instead of pulling a users.list every time.

note that I piggybacked on mapIrcToSlack() ... which means i'll need to change all the test cases to be aware that there is a paginateCallOrThrow in the mix ... as it's going to get user info as the maps are updated.  please let me know if you think there is a better way to manage that before i start changing tests ...