### PR TITLE
Make sure channel MODE outputs something instead of empty arg

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -327,6 +327,11 @@ class Irslackd {
   async onIrcMode(ircUser, msg) {
     let target = msg.args[0];
     if (target.substr(0, 1) === '#') {
+      // if its just the channel
+      if (msg.args.length === 1) {
+        // then make sure it has an empty mode string
+        msg.args.push('+');
+      }
       this.ircd.write(ircUser.socket, 'irslackd', 'MODE', msg.args);
     }
   }


### PR DESCRIPTION
Spec(https://tools.ietf.org/html/rfc1459#section-4.2.3.1) isn't clear to me, but looks like second arg should be mandatory

When I remove the channel modes, and /MODE #channel on freenode, I get back `MODE #channel +`, so I think this is the right behavior

Related to https://github.com/kiwiirc/irc-framework/pull/222