### PR TITLE
join: Send RPL_ENDOFNAMES after RPL_NAMREPLY

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1026,6 +1026,7 @@ class Irslackd {
         }).join(' '),
       ]);
     }
+    this.ircd.write(ircUser.socket, 'irslackd', '366', [ ircUser.ircNick, ircChan, ':End of /NAMES list' ]);
   }
   sendIrcChannelPart(ircUser, ircChan) {
     // Unset channel marker and leave IRC channel

--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -115,6 +115,7 @@ async function connectOneIrcClient(t, prefs = []) {
     ircSocket.expect(':test_slack_user JOIN #test_chan_1');
     ircSocket.expect(':irslackd 332 test_slack_user #test_chan_1 :topic1');
     ircSocket.expect(':irslackd 353 test_slack_user = #test_chan_1 :test_slack_user test_slack_user test_slack_fooo test_slack_barr');
+    ircSocket.expect(':irslackd 366 test_slack_user #test_chan_1 :End of /NAMES list');
   };
 
   // Start irslackd
@@ -166,7 +167,7 @@ async function connectOneIrcClient(t, prefs = []) {
     slackRtm: ircUser.slackRtm,
   };
 }
-connectOneIrcClient.planCount = 19;
+connectOneIrcClient.planCount = 20;
 
 exports.MockSlackWebClient = MockSlackWebClient;
 exports.MockSlackRtmClient = MockSlackRtmClient;

--- a/tests/test_join.js
+++ b/tests/test_join.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('irc_join_simple', async(t) => {
-  t.plan(5 + mocks.connectOneIrcClient.planCount);
+  t.plan(6 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('channels.join', { name: 'foobar' }, {
     ok: true,
@@ -25,12 +25,13 @@ test('irc_join_simple', async(t) => {
   c.ircSocket.expect(':test_slack_user JOIN #foobar');
   c.ircSocket.expect(':irslackd 332 test_slack_user #foobar :foobar topic here');
   c.ircSocket.expect(':irslackd 353 test_slack_user = #foobar :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
+  c.ircSocket.expect(':irslackd 366 test_slack_user #foobar :End of /NAMES list');
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar' ] });
   t.end();
 });
 
 test('irc_join_already_in', async(t) => {
-  t.plan(6 + mocks.connectOneIrcClient.planCount);
+  t.plan(7 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('channels.join', { name: 'foobar' }, {
     ok: true,
@@ -55,12 +56,13 @@ test('irc_join_already_in', async(t) => {
   c.ircSocket.expect(':test_slack_user JOIN #foobar');
   c.ircSocket.expect(':irslackd 332 test_slack_user #foobar :foobar topic here');
   c.ircSocket.expect(':irslackd 353 test_slack_user = #foobar :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
+  c.ircSocket.expect(':irslackd 366 test_slack_user #foobar :End of /NAMES list');
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar' ] });
   t.end();
 });
 
 test('irc_join_csv', async(t) => {
-  t.plan(10 + mocks.connectOneIrcClient.planCount);
+  t.plan(12 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   for (let chan of ['foobar', 'quuxbar']) {
     const chanId = 'C' + chan.toUpperCase();
@@ -77,13 +79,14 @@ test('irc_join_csv', async(t) => {
     c.ircSocket.expect(':test_slack_user JOIN #' + chan);
     c.ircSocket.expect(':irslackd 332 test_slack_user #' + chan + ' :' + chan + ' topic here');
     c.ircSocket.expect(':irslackd 353 test_slack_user = #' + chan + ' :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
+    c.ircSocket.expect(':irslackd 366 test_slack_user #' + chan + ' :End of /NAMES list');
   }
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar,#quuxbar' ] });
   t.end();
 });
 
 test('slack_join', async(t) => {
-  t.plan(7 + mocks.connectOneIrcClient.planCount);
+  t.plan(8 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('conversations.info',    { channel: 'CKOOLKEITH' }, { ok: true, channel: { id: 'CKOOLKEITH', name: 'koolkeith', topic: { value: 'kool topic here' }}});
   c.slackWeb.expect('conversations.info',    { channel: 'CKOOLKEITH' }, { ok: true, channel: { id: 'CKOOLKEITH', name: 'koolkeith', topic: { value: 'kool topic here' }}}); // TODO can be more efficient here
@@ -96,6 +99,7 @@ test('slack_join', async(t) => {
   c.ircSocket.expect(':test_slack_user JOIN #koolkeith');
   c.ircSocket.expect(':irslackd 332 test_slack_user #koolkeith :kool topic here');
   c.ircSocket.expect(':irslackd 353 test_slack_user = #koolkeith :test_slack_user test_slack_user test_slack_quux newguy');
+  c.ircSocket.expect(':irslackd 366 test_slack_user #koolkeith :End of /NAMES list');
   await c.daemon.onSlackChannelJoined(c.ircUser, { channel: { id: 'CKOOLKEITH' }});
   t.end();
 });

--- a/tests/test_mpim.js
+++ b/tests/test_mpim.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('slack_mpim_open', async(t) => {
-  t.plan(6 + mocks.connectOneIrcClient.planCount);
+  t.plan(7 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('conversations.info', { channel: 'G1234GROUP' }, {
     ok: true,
@@ -31,6 +31,7 @@ test('slack_mpim_open', async(t) => {
   c.ircSocket.expect(':test_slack_user JOIN #mpdm-user1--user2--user3--user4-1');
   c.ircSocket.expect(':irslackd 332 test_slack_user #mpdm-user1--user2--user3--user4-1 :Group messaging');
   c.ircSocket.expect(':irslackd 353 test_slack_user = #mpdm-user1--user2--user3--user4-1 :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
+  c.ircSocket.expect(':irslackd 366 test_slack_user #mpdm-user1--user2--user3--user4-1 :End of /NAMES list');
   await c.daemon.onSlackMpimOpen(c.ircUser, {
     user: 'U1234USER',
     channel: 'G1234GROUP',

--- a/tests/test_rename.js
+++ b/tests/test_rename.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const mocks = require('./mocks');
 
 test('slack_rename', async(t) => {
-  t.plan(6 + mocks.connectOneIrcClient.planCount);
+  t.plan(7 + mocks.connectOneIrcClient.planCount);
   const c = await mocks.connectOneIrcClient(t);
   c.slackWeb.expect('conversations.info', { channel: 'C1234CHAN1' }, {
     ok: true,
@@ -23,6 +23,7 @@ test('slack_rename', async(t) => {
   c.ircSocket.expect(':test_slack_user JOIN #test_chan_new');
   c.ircSocket.expect(':irslackd 332 test_slack_user #test_chan_new :foobar topic here');
   c.ircSocket.expect(':irslackd 353 test_slack_user = #test_chan_new :test_slack_user test_slack_user test_slack_barr');
+  c.ircSocket.expect(':irslackd 366 test_slack_user #test_chan_new :End of /NAMES list');
   await c.daemon.onSlackChannelRename(c.ircUser, {
     type: 'channel_rename',
     channel: {


### PR DESCRIPTION
RFC2821 dictates that an RPL_NAMREPLY sequence must be terminated with
an RPL_ENDOFNAMES message.

This improves interoperability with bouncers.