### PR TITLE
Improve IRC test accuracy

### DIFF
--- a/tests/mocks.js
+++ b/tests/mocks.js
@@ -17,16 +17,18 @@ class MockIrcSocket extends EventEmitter {
   }
   write(actualLine) {
     const testMsg = 'Expected IRCd line: ' + actualLine;
-    for (let i = 0; i < this.expectedLines.length; i++) {
-      let expectedLine = this.expectedLines[i];
-      if (expectedLine.trim() === actualLine.trim()) {
-        this.t.ok(true, testMsg);
-        this.expectedLines.splice(i, 1);
-        return true;
-      }
+    if (this.expectedLines.length === 0) {
+      this.t.fail('Expected nothing, but got IRCd line: ' + actualLine);
+      return false;
     }
-    this.t.fail(testMsg);
-    return false;
+    let expected = this.expectedLines[0];
+    if (expected.trim() !== actualLine.trim()) {
+      this.t.fail('Expected IRCd line: ' + expected + ', but got: ' + actualLine);
+      return false;
+    }
+    this.expectedLines.shift();
+    this.t.ok(true, testMsg);
+    return true;
   }
   end() {
   }
@@ -110,12 +112,12 @@ async function connectOneIrcClient(t, prefs = []) {
   // Define setExpectedIrcCalls
   const setExpectedIrcCalls = (ircSocket) => {
     ircSocket.expect(':test_orig_nick NICK test_slack_user');
-    ircSocket.expect(':irslackd 001 test_slack_user irslackd');
-    ircSocket.expect(':irslackd 376 test_slack_user :End of MOTD');
     ircSocket.expect(':test_slack_user JOIN #test_chan_1');
     ircSocket.expect(':irslackd 332 test_slack_user #test_chan_1 :topic1');
     ircSocket.expect(':irslackd 353 test_slack_user = #test_chan_1 :test_slack_user test_slack_user test_slack_fooo test_slack_barr');
     ircSocket.expect(':irslackd 366 test_slack_user #test_chan_1 :End of /NAMES list');
+    ircSocket.expect(':irslackd 001 test_slack_user irslackd');
+    ircSocket.expect(':irslackd 376 test_slack_user :End of MOTD');
   };
 
   // Start irslackd

--- a/tests/test_ctcp.js
+++ b/tests/test_ctcp.js
@@ -17,6 +17,7 @@ test('irc_ctcp_action', async(t) => {
     ts: '1234.5678',
   });
   await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ '#test_chan_1', '\x01ACTION me\x01' ] });
+  c.end();
   t.end();
 });
 
@@ -31,6 +32,7 @@ test('slack_me_message', async(t) => {
     ts: '1234.5678',
     subtype: 'me_message',
   });
+  c.end();
   t.end();
 });
 
@@ -42,6 +44,7 @@ test('slack_ctcp_typing_disabled', async(t) => {
     user: 'U1234USER',
     channel: 'C1234CHAN1',
   });
+  c.end();
   t.end();
 });
 
@@ -54,5 +57,6 @@ test('slack_ctcp_typing_enabled', async(t) => {
     user: 'U1234USER',
     channel: 'C1234CHAN1',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_handler.js
+++ b/tests/test_handler.js
@@ -16,6 +16,7 @@ test('irc_handler', async(t) => {
   let maxChecks = 10;
   (function checkMarker() {
     if (marker) {
+      c.end();
       t.end();
     } else if (maxChecks--) {
       console.log('Sleeping...');
@@ -39,6 +40,7 @@ test('slack_handler', async(t) => {
   let maxChecks = 10;
   (function checkMarker() {
     if (marker) {
+      c.end();
       t.end();
     } else if (maxChecks--) {
       console.log('Sleeping...');

--- a/tests/test_invite.js
+++ b/tests/test_invite.js
@@ -16,5 +16,6 @@ test('irc_invite', async(t) => {
 
   c.ircSocket.expect(':irslackd 341 test_slack_user test_slack_quux #test_chan_1');
   await c.daemon.onIrcInvite(c.ircUser, { args: ['test_slack_quux', '#test_chan_1'] });
+  c.end();
   t.end();
 });

--- a/tests/test_join.js
+++ b/tests/test_join.js
@@ -27,6 +27,7 @@ test('irc_join_simple', async(t) => {
   c.ircSocket.expect(':irslackd 353 test_slack_user = #foobar :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
   c.ircSocket.expect(':irslackd 366 test_slack_user #foobar :End of /NAMES list');
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar' ] });
+  c.end();
   t.end();
 });
 
@@ -58,6 +59,7 @@ test('irc_join_already_in', async(t) => {
   c.ircSocket.expect(':irslackd 353 test_slack_user = #foobar :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
   c.ircSocket.expect(':irslackd 366 test_slack_user #foobar :End of /NAMES list');
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar' ] });
+  c.end();
   t.end();
 });
 
@@ -82,6 +84,7 @@ test('irc_join_csv', async(t) => {
     c.ircSocket.expect(':irslackd 366 test_slack_user #' + chan + ' :End of /NAMES list');
   }
   await c.daemon.onIrcJoin(c.ircUser, { args: [ '#foobar,#quuxbar' ] });
+  c.end();
   t.end();
 });
 
@@ -101,6 +104,7 @@ test('slack_join', async(t) => {
   c.ircSocket.expect(':irslackd 353 test_slack_user = #koolkeith :test_slack_user test_slack_user test_slack_quux newguy');
   c.ircSocket.expect(':irslackd 366 test_slack_user #koolkeith :End of /NAMES list');
   await c.daemon.onSlackChannelJoined(c.ircUser, { channel: { id: 'CKOOLKEITH' }});
+  c.end();
   t.end();
 });
 
@@ -111,6 +115,7 @@ test('no_double_join', async(t) => {
   c.ircSocket.expect(':test_slack_quux JOIN #test_chan_1');
   await c.daemon.onSlackMemberJoinedChannel(c.ircUser, { channel: 'C1234CHAN1', user: 'U1235QUUX' });
   await c.daemon.onSlackMessage(c.ircUser, { subtype: 'channel_join', channel: 'C1234CHAN1', user: 'U1235QUUX' });
+  c.end();
   t.end();
 });
 
@@ -121,5 +126,6 @@ test('no_double_part', async(t) => {
   c.ircSocket.expect(':test_slack_barr PART #test_chan_1');
   await c.daemon.onSlackMemberLeftChannel(c.ircUser, { channel: 'C1234CHAN1', user: 'U1235BARR' });
   await c.daemon.onSlackMessage(c.ircUser, { subtype: 'channel_leave', channel: 'C1234CHAN1', user: 'U1235BARR' });
+  c.end();
   t.end();
 });

--- a/tests/test_kick.js
+++ b/tests/test_kick.js
@@ -14,5 +14,6 @@ test('irc_kick', async(t) => {
   });
   c.ircSocket.expect(':test_slack_user KICK #test_chan_1 test_slack_fooo');
   await c.daemon.onIrcKick(c.ircUser, { args: ['#test_chan_1', 'test_slack_fooo'] });
+  c.end();
   t.end();
 });

--- a/tests/test_list.js
+++ b/tests/test_list.js
@@ -19,5 +19,6 @@ test('irc_list', async(t) => {
   c.ircSocket.expect(':irslackd 322 test_slack_user #chan3 3 :chan3 topic');
   c.ircSocket.expect(':irslackd 323 test_slack_user :End of LIST');
   await c.daemon.onIrcList(c.ircUser, { args: [] });
+  c.end();
   t.end();
 });

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -24,6 +24,7 @@ test('irc_privmsg', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -56,6 +57,7 @@ test('irc_privmsg_with_err', async(t) => {
     ts: '1234.5678',
   });
   await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ '#test_chan_1', 'hello world after error' ] });
+  c.end();
   t.end();
 });
 
@@ -69,6 +71,7 @@ test('slack_privmsg', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -82,6 +85,7 @@ test('slack_ircize_text', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -95,6 +99,7 @@ test('slack_ircize_text_backticks', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -112,6 +117,7 @@ test('slack_ircize_text_backticks_two', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -135,6 +141,7 @@ test('irc_slackize_text', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });
 
@@ -158,5 +165,6 @@ test('irc_no_slackize_text', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_mpim.js
+++ b/tests/test_mpim.js
@@ -41,5 +41,6 @@ test('slack_mpim_open', async(t) => {
   }, {
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_parse_cmd.js
+++ b/tests/test_parse_cmd.js
@@ -27,5 +27,6 @@ test('parse_at_slack_command', async(t) => {
   t.deepEqual(c.daemon.parseAtSlackCmd('-trailing='),                   [{trailing: true}, []]);
   t.deepEqual(c.daemon.parseAtSlackCmd('-trailing'),                    [{trailing: true}, []]);
   t.deepEqual(c.daemon.parseAtSlackCmd('-trailing=""'),                 [{trailing: ''}, []]);
+  c.end();
   t.end();
 });

--- a/tests/test_part.js
+++ b/tests/test_part.js
@@ -9,6 +9,7 @@ test('irc_part', async(t) => {
   c.slackWeb.expect('conversations.leave', { channel: 'C1234CHAN1' }, { ok: true });
   c.ircSocket.expect(':test_slack_user PART #test_chan_1');
   await c.daemon.onIrcPart(c.ircUser, { args: [ '#test_chan_1' ] });
+  c.end();
   t.end();
 });
 
@@ -18,5 +19,6 @@ test('slack_part', async(t) => {
   c.slackWeb.expect('conversations.leave', { channel: 'C1234CHAN1' }, { ok: true });
   c.ircSocket.expect(':test_slack_user PART #test_chan_1');
   await c.daemon.onSlackChannelLeft(c.ircUser, { channel: 'C1234CHAN1' });
+  c.end();
   t.end();
 });

--- a/tests/test_preferences.js
+++ b/tests/test_preferences.js
@@ -18,6 +18,7 @@ test('pref_no-reactions', async(t) => {
     },
     event_ts: '1360782804.083113',
   });
+  c.end();
   t.end();
 });
 
@@ -31,5 +32,6 @@ test('pref_no-threads', async(t) => {
     ts: '1234.5678',
     thread_ts: '12345678.901234',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_presence.js
+++ b/tests/test_presence.js
@@ -16,6 +16,7 @@ test('slack_presence_change_noop', async(t) => {
     presence: 'active',
     user: 'U1234USER',
   });
+  c.end();
   t.end();
 });
 
@@ -28,6 +29,7 @@ test('slack_presence_change_away', async(t) => {
     presence: 'away',
     user: 'U1234USER',
   });
+  c.end();
   t.end();
 });
 
@@ -40,5 +42,6 @@ test('slack_presence_change_active', async(t) => {
     presence: 'active',
     user: 'U1234USER',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_react.js
+++ b/tests/test_react.js
@@ -19,5 +19,6 @@ test('slack_react', async(t) => {
     },
     event_ts: '1360782804.083113',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_rename.js
+++ b/tests/test_rename.js
@@ -32,5 +32,6 @@ test('slack_rename', async(t) => {
       created: 1527736458,
     },
   });
+  c.end();
   t.end();
 });

--- a/tests/test_topic.js
+++ b/tests/test_topic.js
@@ -18,6 +18,7 @@ test('irc_topic_set', async(t) => {
   c.ircSocket.expect(':irslackd 332 test_slack_user #test_chan_1 :new topic diff');
   await c.daemon.onIrcTopic(c.ircUser, { args: [ '#test_chan_1', 'new topic' ] });
 
+  c.end();
   t.end();
 });
 
@@ -35,5 +36,6 @@ test('irc_topic_get', async(t) => {
   c.ircSocket.expect(':irslackd 332 test_slack_user #test_chan_1 :whatever topic');
   await c.daemon.onIrcTopic(c.ircUser, { args: [ '#test_chan_1' ] });
 
+  c.end();
   t.end();
 });

--- a/tests/test_usergroup.js
+++ b/tests/test_usergroup.js
@@ -30,5 +30,6 @@ test('slack_usergroup_updated', async(t) => {
     channel: 'C1234CHAN1',
     ts: '1234.5678',
   });
+  c.end();
   t.end();
 });

--- a/tests/test_whois.js
+++ b/tests/test_whois.js
@@ -15,5 +15,6 @@ test('irc_whois', async(t) => {
   });
   c.ircSocket.expect(':irslackd 311 test_slack_user test_slack_quux test_slack_quux irslackd * :John Quux');
   await c.daemon.onIrcWhois(c.ircUser, { args: [ 'test_slack_quux' ] });
+  c.end();
   t.end();
 });


### PR DESCRIPTION
IRC message order is very important, but MockIrcSocket accepted messages in any order. Furthermore, a test failure would not occur for expected messages that were never written, only incorrectly written messages would cause a failure.

This PR makes MockIrcSocket enforce strict ordering of expected messages, and implements "end" with a test for remaining expected lines.

This PR is based on https://github.com/adsr/irslackd/pull/92 due to them both modifying the same test in a way that'll cause a conflict if standalone, so https://github.com/adsr/irslackd/pull/92 should be merged first.