### PR TITLE
Encode @here and @channel.

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1119,7 +1119,7 @@ class Irslackd {
   }
   ircizeTextChunk(ircUser, text) {
     if (text.indexOf('<') === -1) return text;
-    return text.replace(/<(http|mailto:|#|@|!subteam\^)([^>|]+)[^>]*>/g, (match, prefix, slackId) => {
+    return text.replace(/<(http|mailto:|#|@|!subteam\^|!here|!channel)([^>|]*)[^>]*>/g, (match, prefix, slackId) => {
       if (prefix === 'http') {
         let link = match.substr(1, match.length - 2);
         let pipe = link.lastIndexOf('|');
@@ -1127,6 +1127,10 @@ class Irslackd {
         return link;
       } else if (prefix === 'mailto:') {
         return slackId;
+      } else if (prefix === '!here') {
+        return '@here';
+      } else if (prefix === '!channel') {
+        return '@channel';
       }
       let ircTarget = ircUser.slackToIrc.get(slackId); // TODO resolveSlackTarget?
       if (!ircTarget) return match;
@@ -1141,21 +1145,31 @@ class Irslackd {
   slackizeText(ircUser, text) {
     if (text.indexOf('@') === -1 && text.indexOf('#') === -1) return text;
     return text.replace(/([^\w-]|^)([#@])([\w-]+)/g, (match, lookbehind, prefix, ircTarget) => {
-      if (prefix === '#') ircTarget = '#' + ircTarget;
-      let slackTarget = ircUser.ircToSlack.get(ircTarget);
-      if (!slackTarget) {
-        this.logError(ircUser, 'No slackizeText match for: ' + ircTarget);
-        return match;
-      }
       let suffix = '';
-      if (prefix === '#') {
-        prefix = '#';
-        suffix = '|' + ircTarget.substr(1);
-      } else if (slackTarget.substr(0, 1) === 'U') {
-        prefix = '@';
+      let slackTarget = '';
+
+      if (prefix === '#') ircTarget = '#' + ircTarget;
+
+      if ((ircTarget === 'here') || (ircTarget === 'channel')) {
+        prefix = '!';
+        slackTarget = ircTarget;
       } else {
-        prefix = '!subteam^';
-        suffix = '|@' + ircTarget;
+        slackTarget = ircUser.ircToSlack.get(ircTarget);
+
+        if (!slackTarget) {
+          this.logError(ircUser, 'No slackizeText match for: ' + ircTarget);
+          return match;
+        }
+
+        if (prefix === '#') {
+          prefix = '#';
+          suffix = '|' + ircTarget.substr(1);
+        } else if (slackTarget.substr(0, 1) === 'U') {
+          prefix = '@';
+        } else {
+          prefix = '!subteam^';
+          suffix = '|@' + ircTarget;
+        }
       }
       return lookbehind + '<' + prefix + slackTarget + suffix + '>';
     });

--- a/tests/test_message.js
+++ b/tests/test_message.js
@@ -168,3 +168,79 @@ test('irc_no_slackize_text', async(t) => {
   c.end();
   t.end();
 });
+
+test('slack_ircize_here', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.ircSocket.expect(':test_slack_user PRIVMSG #test_chan_1 :hello @here ');
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello <!here>',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  c.end();
+  t.end();
+});
+
+test('irc_slackize_here', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.slackWeb.expect('chat.postMessage', {
+    channel: 'C1234CHAN1',
+    text: 'hello <!here>',
+    as_user: true,
+    thread_ts: null,
+  }, {
+    ok: true,
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ '#test_chan_1', 'hello @here' ] });
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello <!here>',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  c.end();
+  t.end();
+});
+
+test('slack_ircize_channel', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.ircSocket.expect(':test_slack_user PRIVMSG #test_chan_1 :hello @channel');
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello <!channel>',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  c.end();
+  t.end();
+});
+
+test('irc_slackize_channel', async(t) => {
+  t.plan(1 + mocks.connectOneIrcClient.planCount);
+  const c = await mocks.connectOneIrcClient(t);
+  c.slackWeb.expect('chat.postMessage', {
+    channel: 'C1234CHAN1',
+    text: 'hello <!channel>',
+    as_user: true,
+    thread_ts: null,
+  }, {
+    ok: true,
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ '#test_chan_1', 'hello @channel' ] });
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello <!channel>',
+    user: 'U1234USER',
+    channel: 'C1234CHAN1',
+    ts: '1234.5678',
+  });
+  c.end();
+  t.end();
+});


### PR DESCRIPTION
This commit is meant to address issue #30.  This changeset adds specific
handling for encoding @here and @channel monickers, along with
associated tests.