### PR TITLE
Remove numeric suffix from short group chat names.

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1185,11 +1185,11 @@ class Irslackd {
   }
   getIrcChannelName(ircUser, slackName) {
     if (ircUser.shortGroupChatNamesEnabled() && (slackName.substr(0, 4) === 'mpdm')) {
-      // Group chat names are of the form #mpdm-myself--user1--user2--user3
+      // Group chat names are of the form #mpdm-myself--user1--user2--user3-n
+      // Remove "#mpdm-" prefix and numeric suffix
+      let nickstr = slackName.substr(5).replace(/-\d+$/, '');
       let nicks =
-        slackName
-          // Remove "#mpdm-" prefix
-          .substr(5)
+        nickstr
           // Split out the participant names
           .split('--')
           // Take current user nick out as it's redundant

--- a/tests/test_mpim.js
+++ b/tests/test_mpim.js
@@ -70,10 +70,10 @@ test('slack_short_group_chat_names', async(t) => {
     'U1235BAZZ',
     'U1235QUUX',
   ]});
-  c.ircSocket.expect(':test_slack_user JOIN &user2-user3-user4-1');
-  c.ircSocket.expect(':irslackd 332 test_slack_user &user2-user3-user4-1 :Group messaging');
-  c.ircSocket.expect(':irslackd 353 test_slack_user = &user2-user3-user4-1 :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
-  c.ircSocket.expect(':irslackd 366 test_slack_user &user2-user3-user4-1 :End of /NAMES list');
+  c.ircSocket.expect(':test_slack_user JOIN &user2-user3-user4');
+  c.ircSocket.expect(':irslackd 332 test_slack_user &user2-user3-user4 :Group messaging');
+  c.ircSocket.expect(':irslackd 353 test_slack_user = &user2-user3-user4 :test_slack_user test_slack_user test_slack_barr test_slack_bazz test_slack_quux');
+  c.ircSocket.expect(':irslackd 366 test_slack_user &user2-user3-user4 :End of /NAMES list');
   await c.daemon.onSlackMpimOpen(c.ircUser, {
     user: 'U1234USER',
     channel: 'G1234GROUP',


### PR DESCRIPTION
I noticed this little glitch in the last push but didn't think it was a
wart worth fixing, but then I noticed something amusing:  the numeric
suffixed (i.e. "-1") becomes part of the last nick name.  Well, if your
own nickname is the last nick in the channel name, then it doesn't get
pulled off, which means the abbreviation isn't complete.  Oops.

This changeset tweaks this behaviour so the numeric suffix is also
pulled off, which then corrects this knock-on effect.

TBH, I'm not sure why Slack puts that "-1" at the end of mpdm's...
unless you can have more than one with the same group of people
simultaneously?  Seems unlikely, though...