### PR TITLE
Fix 103

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1017,9 +1017,9 @@ class Irslackd {
     // Try conversations.info
     let convo = await ircUser.slackWeb.apiCallOrThrow('conversations.info', { channel: slackChan });
 
-    // If it's an im, pass to resolveSlackUser
+    // If it's an im, return the current user's nick, as they're the target.
     if (convo.channel.is_im) {
-      return this.resolveSlackUser(ircUser, convo.channel.user);
+      return ircUser.ircNick
     }
 
     // Set cache; return

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -1019,7 +1019,7 @@ class Irslackd {
 
     // If it's an im, return the current user's nick, as they're the target.
     if (convo.channel.is_im) {
-      return ircUser.ircNick
+      return ircUser.ircNick;
     }
 
     // Set cache; return

--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -979,7 +979,7 @@ class Irslackd {
       ircNick = 'unknown';
     }
     if (event.channel) {
-      ircChan = this.resolveSlackChannel(ircUser, event.channel);
+      ircChan = this.resolveSlackChannel(ircUser, ircNick, event.channel);
     }
     try {
       if (ircNick) ircNick = await ircNick;
@@ -1009,7 +1009,7 @@ class Irslackd {
     }
     return slackUser;
   }
-  async resolveSlackChannel(ircUser, slackChan) {
+  async resolveSlackChannel(ircUser, ircNick, slackChan) {
     // Check cache
     let ircChan = ircUser.slackToIrc.get(slackChan);
     if (ircChan) return ircChan;
@@ -1017,9 +1017,14 @@ class Irslackd {
     // Try conversations.info
     let convo = await ircUser.slackWeb.apiCallOrThrow('conversations.info', { channel: slackChan });
 
-    // If it's an im, return the current user's nick, as they're the target.
     if (convo.channel.is_im) {
-      return ircUser.ircNick;
+      if (ircNick === ircUser.ircNick) {
+        // It's an IM and we're the sender, so the target is the other user
+        return this.resolveSlackUser(ircUser, convo.channel.user);
+      } else {
+        // It's an IM and we're not the sender, so the target is us
+        return ircUser.ircNick;
+      }
     }
 
     // Set cache; return


### PR DESCRIPTION
The target for a direct message should be set to the current user's nick, not the name of the sender.
