### PR TITLE
Fix for broken DM and MPDM channel parting.

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -275,7 +275,11 @@ class Irslackd {
     }
 
     // Leave Slack channel
-    await ircUser.slackWeb.apiCallOrThrow('conversations.leave', { channel: slackChan });
+    if (this.isNormalChannel(ircChan)) {
+      await ircUser.slackWeb.apiCallOrThrow('conversations.leave', { channel: slackChan });
+    } else {
+      await ircUser.slackWeb.apiCallOrThrow('conversations.close', { channel: slackChan });
+    }
 
     // Unset channel marker and leave IRC channel
     this.sendIrcChannelPart(ircUser, ircChan);


### PR DESCRIPTION
When parting a regular channel you call conversations.leave.  But for DMs and MPDMs you're supposed to call conversations.close.