### PR TITLE
Fix for issue #103

### DIFF
--- a/lib/irslackd.js
+++ b/lib/irslackd.js
@@ -979,7 +979,7 @@ class Irslackd {
       ircNick = 'unknown';
     }
     if (event.channel) {
-      ircChan = this.resolveSlackChannel(ircUser, event.channel);
+      ircChan = this.resolveSlackChannel(ircUser, event.channel, ircNick);
     }
     try {
       if (ircNick) ircNick = await ircNick;
@@ -1009,7 +1009,7 @@ class Irslackd {
     }
     return slackUser;
   }
-  async resolveSlackChannel(ircUser, slackChan) {
+  async resolveSlackChannel(ircUser, slackChan, ircNick) {
     // Check cache
     let ircChan = ircUser.slackToIrc.get(slackChan);
     if (ircChan) return ircChan;
@@ -1017,9 +1017,14 @@ class Irslackd {
     // Try conversations.info
     let convo = await ircUser.slackWeb.apiCallOrThrow('conversations.info', { channel: slackChan });
 
-    // If it's an im, pass to resolveSlackUser
     if (convo.channel.is_im) {
-      return this.resolveSlackUser(ircUser, convo.channel.user);
+      if (await ircNick === await ircUser.ircNick) {
+        // It's an IM and we're the sender, so the target is the other user
+        return this.resolveSlackUser(ircUser, convo.channel.user);
+      } else {
+        // It's an IM and we're not the sender, so the target is us
+        return ircUser.ircNick;
+      }
     }
 
     // Set cache; return

--- a/tests/test_im.js
+++ b/tests/test_im.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const test = require('tape');
+const mocks = require('./mocks');
+
+// Test sending an IM to a target user
+test('slack_im_send', async(t) => {
+  t.plan(4 + mocks.connectOneIrcClient.planCount);
+
+  const c = await mocks.connectOneIrcClient(t);
+
+  c.slackWeb.expect('conversations.open', { users: 'U1235FOOO' }, {
+    ok: true,
+    user: 'U1235FOOO',
+    channel: {
+      id: 'D1235CHAN1',
+    },
+  });
+
+  c.slackWeb.expect('chat.postMessage', {
+    channel: 'D1235CHAN1',
+    text: 'hello world',
+    as_user: true,
+    thread_ts: null,
+  }, {
+    ok: true,
+    channel: 'D1235CHAN1',
+    ts: '1234.5678',
+  });
+
+  c.slackWeb.expect('conversations.info', { channel: 'D1235CHAN1' }, {
+    ok: true,
+    channel: {
+      user: 'U1235FOOO',
+      id: 'D1235CHAN1',
+      is_im: true,
+    },
+  });
+
+  // We get this when the message is echoed back to us.
+  c.ircSocket.expect(':test_slack_fooo PRIVMSG test_slack_user :hello world');
+
+  await c.daemon.onIrcPrivmsg(c.ircUser, { args: [ 'test_slack_fooo', 'hello world' ] });
+
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello world',
+    user: 'U1235FOOO',
+    channel: 'D1235CHAN1',
+  });
+
+  c.end();
+  t.end();
+});
+
+// Receiving an IM from another user that's not us
+test('slack_im_receive', async(t) => {
+  t.plan(2 + mocks.connectOneIrcClient.planCount);
+
+  const c = await mocks.connectOneIrcClient(t);
+
+  c.slackWeb.expect('conversations.info', { channel: 'D1235CHAN1' }, {
+    ok: true,
+    channel: {
+      user: 'U1235FOOO',
+      id: 'D1235CHAN1',
+      is_im: true,
+    },
+  });
+
+  // We get this when the message is echoed back to us.
+  c.ircSocket.expect(':test_slack_fooo PRIVMSG test_slack_user :hello world');
+
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello world',
+    user: 'U1235FOOO',
+    channel: 'D1235CHAN1',
+  });
+
+  c.end();
+  t.end();
+});
+
+// Receiving an IM from ourselves (e.g. sent from a different client)
+test('slack_im_receive_from_self', async(t) => {
+  t.plan(2 + mocks.connectOneIrcClient.planCount);
+
+  const c = await mocks.connectOneIrcClient(t);
+
+  c.slackWeb.expect('conversations.info', { channel: 'D1235CHAN1' }, {
+    ok: true,
+    channel: {
+      user: 'U1235FOOO',
+      id: 'D1235CHAN1',
+      is_im: true,
+    },
+  });
+
+  // We get this when the message is echoed back to us.
+  c.ircSocket.expect(':test_slack_user PRIVMSG test_slack_fooo :hello world');
+
+  await c.daemon.onSlackMessage(c.ircUser, {
+    text: 'hello world',
+    user: 'U1234USER',
+    channel: 'D1235CHAN1',
+  });
+
+  c.end();
+  t.end();
+});


### PR DESCRIPTION
The source and target for a direct message depend on who is chatting
from each side of the conversation.

As a result, we have to look at the source nickname for the message and
compare it to our own, and then set the source and target appropriately.